### PR TITLE
docs: add GitHub discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,0 +1,14 @@
+title: "[General]: "
+labels: ["general"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is a place for general discussions that don't fit into other categories.
+  - type: textarea
+    id: discussion
+    attributes:
+      label: Discussion Topic
+      description: What would you like to discuss?
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,24 @@
+title: "[Idea]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an idea! Please explain your idea clearly so we can understand the value it brings.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your idea related to a problem? Please describe.
+      placeholder: I am frustrated when...
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+      placeholder: I would like to be able to...
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: "Have you considered any alternatives? Why didn't they work?"

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,21 @@
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in the project and for taking the time to ask a question!
+  - type: textarea
+    id: question
+    attributes:
+      label: What is your question?
+      description: Please describe your question in detail.
+      placeholder: I am trying to do X, but I am not sure how to approach it...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Provide any context regarding your question.
+      placeholder: I am using version X.Y.Z...


### PR DESCRIPTION
## Description

This PR adds standard discussion templates to the repository to structure community interactions better. It includes templates for Q&A, Ideas, and General discussions.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build system / CI changes
- [ ] Other (please describe):

## Related Issues

- Related to #11

## Changes Made

### Documentation Changes
- Added \`.github/DISCUSSION_TEMPLATE/q-a.yml\`: Template for questions.
- Added \`.github/DISCUSSION_TEMPLATE/ideas.yml\`: Template for feature requests and ideas.
- Added \`.github/DISCUSSION_TEMPLATE/general.yml\`: Template for general discussions.

## ADR Requirements

- [ ] This change requires an ADR
- [x] This change does not require an ADR
- [ ] ADR status: N/A

## Safety Considerations

- [x] This PR has no safety/security implications

## Testing

- [x] Manual testing performed
  - Verified files were created in the correct directory.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [x] No new warnings generated
- [x] Changes are backward compatible (or breaking changes are documented)