### PR TITLE
feat(memory): Phase 1.3.1 - Parse UEFI memory map

### DIFF
--- a/boot/src/main.rs
+++ b/boot/src/main.rs
@@ -460,17 +460,31 @@ fn kernel_main(boot_info: &KernelBootInfo) -> ! {
     serial_write_str("Hello from Ferrous!\r\n");
     serial_write_str("\r\n");
 
-    // Report memory map summary via serial.
-    serial_write_str("Memory map entries: ");
-    serial_write_usize(boot_info.memory_map.count);
-    serial_write_str("\r\n");
+    // -----------------------------------------------------------------------
+    // Step 5: Parse and report the physical memory map.
+    //
+    // Iterates over the KernelMemoryMap received from the bootloader, prints
+    // each region with its classification and size, then summarises totals.
+    //
+    // Note: in Phase 1 this is an inline analysis. The canonical MemoryMap
+    // type (Phase 1.3.1) lives in ferrous-boot-info and is accessible via
+    // kernel::memory after the kernel binary is separated in Phase 2.
+    print_memory_map(&boot_info.memory_map);
 
     if boot_info.acpi_rsdp != 0 {
-        serial_write_str("[INFO] ACPI RSDP present\r\n");
+        serial_write_str("[INFO] ACPI RSDP: 0x");
+        serial_write_usize_hex(boot_info.acpi_rsdp as usize);
+        serial_write_str("\r\n");
     }
 
     if boot_info.has_framebuffer {
-        serial_write_str("[INFO] Framebuffer present\r\n");
+        serial_write_str("[INFO] Framebuffer: ");
+        serial_write_usize(boot_info.framebuffer.width as usize);
+        serial_write_str("x");
+        serial_write_usize(boot_info.framebuffer.height as usize);
+        serial_write_str(" @ 0x");
+        serial_write_usize_hex(boot_info.framebuffer.base as usize);
+        serial_write_str("\r\n");
     }
 
     serial_write_str(
@@ -1143,6 +1157,122 @@ unsafe fn idt_init() {
         ptr = in(reg) &ptr,
         options(readonly, nostack, preserves_flags),
     );
+}
+
+// ---------------------------------------------------------------------------
+// Memory map analysis (Phase 1.3.1 — inline boot-side implementation)
+//
+// The canonical MemoryMap type lives in ferrous-boot-info. This helper
+// prints the full map and summary statistics over serial during early boot.
+// ---------------------------------------------------------------------------
+
+/// Returns a short label for a UEFI memory type code.
+fn memory_type_label(ty: u32) -> &'static str {
+    use ferrous_boot_info::memory_type;
+    match ty {
+        memory_type::RESERVED => "Reserved",
+        memory_type::LOADER_CODE => "LoaderCode",
+        memory_type::LOADER_DATA => "LoaderData",
+        memory_type::BOOT_SERVICES_CODE => "BootServicesCode",
+        memory_type::BOOT_SERVICES_DATA => "BootServicesData",
+        memory_type::RUNTIME_SERVICES_CODE => "RuntimeServicesCode",
+        memory_type::RUNTIME_SERVICES_DATA => "RuntimeServicesData",
+        memory_type::CONVENTIONAL => "Conventional",
+        memory_type::UNUSABLE => "Unusable",
+        memory_type::ACPI_RECLAIM => "AcpiReclaim",
+        memory_type::ACPI_NON_VOLATILE => "AcpiNonVolatile",
+        memory_type::MMIO => "Mmio",
+        memory_type::MMIO_PORT_SPACE => "MmioPortSpace",
+        memory_type::PERSISTENT_MEMORY => "PersistentMemory",
+        _ => "Unknown",
+    }
+}
+
+/// Returns true for UEFI types that are usable after boot services exit.
+fn is_usable_after_boot(ty: u32) -> bool {
+    use ferrous_boot_info::memory_type;
+    matches!(
+        ty,
+        memory_type::CONVENTIONAL
+            | memory_type::BOOT_SERVICES_CODE
+            | memory_type::BOOT_SERVICES_DATA
+            | memory_type::LOADER_CODE
+            | memory_type::LOADER_DATA
+            | memory_type::ACPI_RECLAIM
+    )
+}
+
+/// Returns true for UEFI types that map to address-space holes (not RAM).
+fn is_mmio(ty: u32) -> bool {
+    use ferrous_boot_info::memory_type;
+    matches!(ty, memory_type::MMIO | memory_type::MMIO_PORT_SPACE)
+}
+
+/// Print the full physical memory map and summary statistics over serial.
+fn print_memory_map(map: &ferrous_boot_info::KernelMemoryMap) {
+    serial_write_str("[INFO] Physical memory map (");
+    serial_write_usize(map.count);
+    serial_write_str(" entries");
+    if map.truncated {
+        serial_write_str(", TRUNCATED");
+    }
+    serial_write_str("):\r\n");
+
+    let mut total_bytes: u64 = 0;
+    let mut usable_bytes: u64 = 0;
+    let mut reclaimable_bytes: u64 = 0;
+
+    for (i, desc) in map.entries().iter().enumerate() {
+        if desc.page_count == 0 {
+            continue;
+        }
+
+        let size = desc.page_count * 4096;
+        let end = desc.phys_start.saturating_add(size);
+
+        if !is_mmio(desc.ty) {
+            total_bytes = total_bytes.saturating_add(size);
+        }
+        if is_usable_after_boot(desc.ty) {
+            if desc.ty == ferrous_boot_info::memory_type::CONVENTIONAL {
+                usable_bytes = usable_bytes.saturating_add(size);
+            } else {
+                reclaimable_bytes = reclaimable_bytes.saturating_add(size);
+            }
+        }
+
+        // Format: "  [ 0] 0x00001000 - 0x00100000  1020 KiB  Conventional"
+        serial_write_str("  [");
+        serial_write_usize(i);
+        serial_write_str("] 0x");
+        serial_write_usize_hex(desc.phys_start as usize);
+        serial_write_str(" - 0x");
+        serial_write_usize_hex(end as usize);
+        serial_write_str("  ");
+        let kib = size / 1024;
+        if kib >= 1024 {
+            serial_write_usize((kib / 1024) as usize);
+            serial_write_str(" MiB");
+        } else {
+            serial_write_usize(kib as usize);
+            serial_write_str(" KiB");
+        }
+        serial_write_str("  ");
+        serial_write_str(memory_type_label(desc.ty));
+        serial_write_str("\r\n");
+    }
+
+    if map.truncated {
+        serial_write_str("[WARN] Memory map was truncated — some regions are missing!\r\n");
+    }
+
+    serial_write_str("[INFO] RAM: ");
+    serial_write_usize((total_bytes / 1024 / 1024) as usize);
+    serial_write_str(" MiB total | ");
+    serial_write_usize((usable_bytes / 1024 / 1024) as usize);
+    serial_write_str(" MiB usable | ");
+    serial_write_usize((reclaimable_bytes / 1024 / 1024) as usize);
+    serial_write_str(" MiB reclaimable\r\n");
 }
 
 /// Halt the CPU permanently.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -12,6 +12,7 @@
 
 pub mod arch;
 pub mod drivers;
+pub mod memory;
 
 use drivers::serial::SerialPort;
 

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -1,0 +1,120 @@
+//! Physical memory management subsystem.
+//!
+//! This module provides the kernel's authoritative view of physical memory,
+//! parsed from the bootloader-provided [`KernelMemoryMap`] at startup.
+//!
+//! # Usage
+//!
+//! During early kernel initialisation (before the allocator runs), call
+//! [`init`] exactly once with the memory map from [`KernelBootInfo`]:
+//!
+//! ```ignore
+//! // SAFETY: called once, single-threaded, interrupts disabled.
+//! let map = unsafe { memory::init(&boot_info.memory_map) }
+//!     .expect("memory map parse failed");
+//! ```
+//!
+//! Thereafter any kernel subsystem can call [`get`] to borrow the map:
+//!
+//! ```ignore
+//! let map = memory::get().expect("memory not initialised");
+//! for region in map.usable_regions() { ... }
+//! ```
+//!
+//! # Re-exports
+//!
+//! The parsing types ([`MemoryMap`], [`MemoryRegionKind`], [`MemoryStats`],
+//! [`ParseError`]) live in [`ferrous_boot_info`] so they can be tested on the
+//! host without targeting `x86_64-unknown-none`. They are re-exported here
+//! for ergonomic access within the kernel.
+
+use core::mem::MaybeUninit;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use ferrous_boot_info::KernelMemoryMap;
+
+pub use ferrous_boot_info::{MemoryMap, MemoryRegionKind, MemoryStats, ParseError};
+
+// ---------------------------------------------------------------------------
+// Global memory map
+// ---------------------------------------------------------------------------
+
+/// Sentinel: set to `true` after [`init`] completes successfully.
+///
+/// Uses `Ordering::Release` on write and `Ordering::Acquire` on read so that
+/// all writes to `MEMORY_MAP` are visible to any thread that observes
+/// `INITIALIZED == true`.  In Phase 1 the kernel is single-core and
+/// interrupts are disabled during init, so the atomic is purely defensive.
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+/// The global physical memory map.
+///
+/// # SAFETY invariant
+///
+/// This static is in one of two states:
+///
+/// 1. **Uninitialised** (`INITIALIZED == false`): only [`init`] may write it.
+/// 2. **Initialised** (`INITIALIZED == true`): immutable from this point on;
+///    safe to take shared references via [`get`].
+///
+/// No mutable reference is ever taken after [`init`] sets `INITIALIZED`.
+// SAFETY: written once in `init()` before INITIALIZED is set to true.
+#[allow(static_mut_refs)]
+static mut MEMORY_MAP: MaybeUninit<MemoryMap> = MaybeUninit::uninit();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Initialise the global kernel memory map.
+///
+/// Parses `source`, stores the result in a `'static` slot, and returns a
+/// reference to it.  This reference is valid for the lifetime of the kernel.
+///
+/// # Errors
+///
+/// Propagates any [`ParseError`] from [`MemoryMap::parse`].
+///
+/// # Safety
+///
+/// - Must be called **exactly once**.
+/// - Must be called **before** any call to [`get`].
+/// - Must be called from a **single-threaded context** with interrupts
+///   disabled (the standard early-boot environment).
+///
+/// Violating any of these invariants is undefined behaviour.
+pub unsafe fn init(source: &KernelMemoryMap) -> Result<&'static MemoryMap, ParseError> {
+    debug_assert!(
+        !INITIALIZED.load(Ordering::Relaxed),
+        "memory::init() called more than once"
+    );
+
+    let map = MemoryMap::parse(source)?;
+
+    // SAFETY: single-threaded, interrupts disabled, INITIALIZED is still
+    // false so no concurrent reader exists.
+    #[allow(static_mut_refs)]
+    MEMORY_MAP.write(map);
+
+    // Release store: all writes to MEMORY_MAP are visible after this.
+    INITIALIZED.store(true, Ordering::Release);
+
+    // SAFETY: MEMORY_MAP was fully written above.
+    #[allow(static_mut_refs)]
+    Ok(MEMORY_MAP.assume_init_ref())
+}
+
+/// Returns a shared reference to the global memory map.
+///
+/// Returns `None` if [`init`] has not been called yet.  After a successful
+/// [`init`] call this function always returns `Some`.
+pub fn get() -> Option<&'static MemoryMap> {
+    if INITIALIZED.load(Ordering::Acquire) {
+        // SAFETY: MEMORY_MAP is fully initialised when INITIALIZED is true
+        // and is never written again after that point.
+        #[allow(static_mut_refs)]
+        Some(unsafe { MEMORY_MAP.assume_init_ref() })
+    } else {
+        None
+    }
+}

--- a/lib/boot-info/src/lib.rs
+++ b/lib/boot-info/src/lib.rs
@@ -217,6 +217,285 @@ impl KernelBootInfo {
 }
 
 // ---------------------------------------------------------------------------
+// Memory map parsing — higher-level view of KernelMemoryMap
+//
+// These types are consumed by the kernel's physical memory allocator.
+// They live here (rather than in the kernel crate) because they operate
+// purely on KernelMemoryMap data and can be tested on the host without
+// targeting x86_64-unknown-none.
+// ---------------------------------------------------------------------------
+
+/// High-level classification of a UEFI memory region.
+///
+/// Groups the raw UEFI memory type codes into kernel-relevant categories.
+/// Use this to decide whether a region may be allocated, reclaimed, or
+/// left alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryRegionKind {
+    /// Available for physical page allocation immediately after boot.
+    Usable,
+    /// Occupied by bootloader code/data; reclaimable once the kernel no
+    /// longer needs the bootloader (after Phase 1 handoff is complete).
+    BootloaderReclaimable,
+    /// Holds ACPI tables; reclaimable after ACPI initialisation (Phase 2+).
+    AcpiReclaimable,
+    /// ACPI firmware non-volatile storage — preserve indefinitely.
+    AcpiNonVolatile,
+    /// Firmware runtime code/data — must remain identity-mapped forever.
+    FirmwareRuntime,
+    /// Memory-mapped I/O — not RAM, never allocate.
+    Mmio,
+    /// NVDIMM persistent memory — requires special driver handling.
+    PersistentMemory,
+    /// Defective RAM reported by firmware.
+    Unusable,
+    /// Firmware-reserved or unrecognised type — do not touch.
+    Reserved,
+}
+
+impl MemoryRegionKind {
+    /// True if the physical allocator may use this region after boot
+    /// reclamation completes (conventional + bootloader + ACPI reclaimable).
+    #[inline]
+    pub fn is_reclaimable_after_boot(self) -> bool {
+        matches!(
+            self,
+            Self::Usable | Self::BootloaderReclaimable | Self::AcpiReclaimable
+        )
+    }
+
+    /// True only for conventional memory — immediately available before any
+    /// reclamation pass.
+    #[inline]
+    pub fn is_immediately_usable(self) -> bool {
+        self == Self::Usable
+    }
+
+    /// Short human-readable label for serial diagnostics.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Usable => "Conventional",
+            Self::BootloaderReclaimable => "BootloaderReclaimable",
+            Self::AcpiReclaimable => "AcpiReclaimable",
+            Self::AcpiNonVolatile => "AcpiNonVolatile",
+            Self::FirmwareRuntime => "FirmwareRuntime",
+            Self::Mmio => "Mmio",
+            Self::PersistentMemory => "PersistentMemory",
+            Self::Unusable => "Unusable",
+            Self::Reserved => "Reserved",
+        }
+    }
+}
+
+impl From<u32> for MemoryRegionKind {
+    fn from(ty: u32) -> Self {
+        match ty {
+            memory_type::CONVENTIONAL => Self::Usable,
+            memory_type::LOADER_CODE
+            | memory_type::LOADER_DATA
+            | memory_type::BOOT_SERVICES_CODE
+            | memory_type::BOOT_SERVICES_DATA => Self::BootloaderReclaimable,
+            memory_type::ACPI_RECLAIM => Self::AcpiReclaimable,
+            memory_type::ACPI_NON_VOLATILE => Self::AcpiNonVolatile,
+            memory_type::RUNTIME_SERVICES_CODE | memory_type::RUNTIME_SERVICES_DATA => {
+                Self::FirmwareRuntime
+            }
+            memory_type::MMIO | memory_type::MMIO_PORT_SPACE => Self::Mmio,
+            memory_type::PERSISTENT_MEMORY => Self::PersistentMemory,
+            memory_type::UNUSABLE => Self::Unusable,
+            _ => Self::Reserved, // RESERVED (0) and any unknown type
+        }
+    }
+}
+
+/// Statistics derived from a parsed memory map.
+///
+/// Computed once during [`MemoryMap::parse()`] and cached inside the map.
+#[derive(Debug, Clone, Copy)]
+pub struct MemoryStats {
+    /// Total physical RAM in bytes (excludes MMIO and firmware runtime).
+    pub total_bytes: u64,
+    /// Bytes of immediately-usable conventional memory.
+    pub usable_bytes: u64,
+    /// Bytes reclaimable after boot (bootloader + ACPI reclaimable).
+    pub reclaimable_bytes: u64,
+    /// Number of valid (non-zero-size) regions in the parsed map.
+    pub region_count: usize,
+    /// Number of immediately-usable (conventional) regions.
+    pub usable_region_count: usize,
+    /// True if the bootloader truncated the map (source had more entries than
+    /// [`MAX_MEMORY_DESCRIPTORS`]).
+    pub is_truncated: bool,
+}
+
+impl MemoryStats {
+    /// Total bytes the allocator may use after all reclamation passes.
+    #[inline]
+    pub fn total_usable_after_boot(self) -> u64 {
+        self.usable_bytes.saturating_add(self.reclaimable_bytes)
+    }
+}
+
+/// Errors returned by [`MemoryMap::parse()`].
+#[derive(Debug)]
+pub enum ParseError {
+    /// The memory map contains zero valid (non-zero-size) entries.
+    Empty,
+    /// A descriptor has a non-page-aligned base address (UEFI spec violation).
+    UnalignedBase {
+        /// Zero-based index of the offending descriptor in the source map.
+        index: usize,
+        /// The misaligned physical address.
+        phys_start: u64,
+    },
+}
+
+/// Zero-value descriptor used to initialise the fixed-size array.
+///
+/// `KernelMemoryDescriptor` is `Copy` and all-zero is a valid sentinel value
+/// (type 0 = RESERVED, size 0 — filtered out during parse).
+const ZERO_DESC: KernelMemoryDescriptor = KernelMemoryDescriptor {
+    ty: 0,
+    _pad: 0,
+    phys_start: 0,
+    page_count: 0,
+    attribute: 0,
+};
+
+/// Parsed and validated physical memory map.
+///
+/// Constructed from the bootloader-provided [`KernelMemoryMap`] during early
+/// kernel initialisation. After construction this is effectively immutable and
+/// serves as the authoritative physical memory layout for the allocator
+/// (Phase 1.3.2 and beyond).
+///
+/// # Obtaining an instance
+///
+/// In the kernel, use `kernel::memory::init(&boot_info.memory_map)` to
+/// initialise the global instance, then `kernel::memory::get()` to borrow it.
+pub struct MemoryMap {
+    // Not derived — KernelMemoryDescriptor's large fixed array makes Debug
+    // output impractical and KernelMemoryDescriptor doesn't derive Debug.
+    // Use stats() for diagnostic output.
+    descriptors: [KernelMemoryDescriptor; MAX_MEMORY_DESCRIPTORS],
+    count: usize,
+    stats: MemoryStats,
+}
+
+impl MemoryMap {
+    /// Parse and validate the bootloader-provided memory map.
+    ///
+    /// Entries with `page_count == 0` are silently skipped — some firmware
+    /// produces zero-size descriptors as padding.
+    ///
+    /// # Errors
+    ///
+    /// - [`ParseError::Empty`]: every entry has zero pages (or `count == 0`).
+    /// - [`ParseError::UnalignedBase`]: a descriptor's `phys_start` is not
+    ///   4 KiB aligned (guaranteed by the UEFI spec; this catches corrupt maps).
+    pub fn parse(source: &KernelMemoryMap) -> Result<Self, ParseError> {
+        let mut descriptors = [ZERO_DESC; MAX_MEMORY_DESCRIPTORS];
+        let mut count = 0usize;
+
+        let mut total_bytes: u64 = 0;
+        let mut usable_bytes: u64 = 0;
+        let mut reclaimable_bytes: u64 = 0;
+        let mut usable_region_count: usize = 0;
+
+        for (i, desc) in source.entries().iter().enumerate() {
+            // Skip zero-size entries emitted by some firmware.
+            if desc.page_count == 0 {
+                continue;
+            }
+
+            // UEFI spec §7.2: EFI_PHYSICAL_ADDRESS must be page-aligned.
+            if desc.phys_start & 0xFFF != 0 {
+                return Err(ParseError::UnalignedBase {
+                    index: i,
+                    phys_start: desc.phys_start,
+                });
+            }
+
+            let size = desc.size_bytes();
+            let kind = MemoryRegionKind::from(desc.ty);
+
+            // Accumulate RAM totals, excluding address-space holes (MMIO).
+            match kind {
+                MemoryRegionKind::Mmio | MemoryRegionKind::FirmwareRuntime => {}
+                _ => total_bytes = total_bytes.saturating_add(size),
+            }
+
+            match kind {
+                MemoryRegionKind::Usable => {
+                    usable_bytes = usable_bytes.saturating_add(size);
+                    usable_region_count += 1;
+                }
+                MemoryRegionKind::BootloaderReclaimable | MemoryRegionKind::AcpiReclaimable => {
+                    reclaimable_bytes = reclaimable_bytes.saturating_add(size);
+                }
+                _ => {}
+            }
+
+            descriptors[count] = *desc;
+            count += 1;
+        }
+
+        if count == 0 {
+            return Err(ParseError::Empty);
+        }
+
+        Ok(Self {
+            descriptors,
+            count,
+            stats: MemoryStats {
+                total_bytes,
+                usable_bytes,
+                reclaimable_bytes,
+                region_count: count,
+                usable_region_count,
+                is_truncated: source.truncated,
+            },
+        })
+    }
+
+    /// Returns memory statistics computed during parsing.
+    #[inline]
+    pub fn stats(&self) -> &MemoryStats {
+        &self.stats
+    }
+
+    /// Returns all valid (non-zero-size) memory descriptors.
+    #[inline]
+    pub fn regions(&self) -> &[KernelMemoryDescriptor] {
+        &self.descriptors[..self.count]
+    }
+
+    /// Iterates over all immediately-usable (conventional) regions.
+    pub fn usable_regions(&self) -> impl Iterator<Item = &KernelMemoryDescriptor> {
+        self.regions()
+            .iter()
+            .filter(|d| MemoryRegionKind::from(d.ty) == MemoryRegionKind::Usable)
+    }
+
+    /// Iterates over all regions usable after boot reclamation.
+    ///
+    /// Includes conventional, bootloader-reclaimable, and ACPI-reclaimable
+    /// regions.
+    pub fn reclaimable_regions(&self) -> impl Iterator<Item = &KernelMemoryDescriptor> {
+        self.regions()
+            .iter()
+            .filter(|d| MemoryRegionKind::from(d.ty).is_reclaimable_after_boot())
+    }
+
+    /// Iterates over all regions matching the given UEFI memory type constant.
+    ///
+    /// Use the [`memory_type`] module constants as the `ty` argument.
+    pub fn regions_of_type(&self, ty: u32) -> impl Iterator<Item = &KernelMemoryDescriptor> {
+        self.regions().iter().filter(move |d| d.ty == ty)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 //
 // Even though this crate is #![no_std], cargo test links std for the test
@@ -434,6 +713,326 @@ mod tests {
         assert_ne!(pixel_format::BGR, pixel_format::BITMASK);
         assert_ne!(pixel_format::BGR, pixel_format::UNKNOWN);
         assert_ne!(pixel_format::BITMASK, pixel_format::UNKNOWN);
+    }
+
+    // -----------------------------------------------------------------------
+    // MemoryRegionKind — classification
+    // -----------------------------------------------------------------------
+
+    fn make_desc(ty: u32, phys_start: u64, page_count: u64) -> KernelMemoryDescriptor {
+        KernelMemoryDescriptor {
+            ty,
+            _pad: 0,
+            phys_start,
+            page_count,
+            attribute: 0,
+        }
+    }
+
+    fn make_map(descs: &[KernelMemoryDescriptor]) -> KernelMemoryMap {
+        let mut map = KernelMemoryMap::new();
+        for (i, desc) in descs.iter().enumerate() {
+            map.descriptors[i] = *desc;
+        }
+        map.count = descs.len();
+        map
+    }
+
+    #[test]
+    fn conventional_memory_is_usable() {
+        let kind = MemoryRegionKind::from(memory_type::CONVENTIONAL);
+        assert_eq!(kind, MemoryRegionKind::Usable);
+        assert!(kind.is_immediately_usable());
+        assert!(kind.is_reclaimable_after_boot());
+    }
+
+    #[test]
+    fn boot_services_are_bootloader_reclaimable() {
+        for ty in [
+            memory_type::BOOT_SERVICES_CODE,
+            memory_type::BOOT_SERVICES_DATA,
+            memory_type::LOADER_CODE,
+            memory_type::LOADER_DATA,
+        ] {
+            let kind = MemoryRegionKind::from(ty);
+            assert_eq!(
+                kind,
+                MemoryRegionKind::BootloaderReclaimable,
+                "type {} should be BootloaderReclaimable",
+                ty
+            );
+            assert!(
+                !kind.is_immediately_usable(),
+                "type {} should not be immediately usable",
+                ty
+            );
+            assert!(
+                kind.is_reclaimable_after_boot(),
+                "type {} should be reclaimable after boot",
+                ty
+            );
+        }
+    }
+
+    #[test]
+    fn acpi_reclaim_is_reclaimable_after_boot() {
+        let kind = MemoryRegionKind::from(memory_type::ACPI_RECLAIM);
+        assert_eq!(kind, MemoryRegionKind::AcpiReclaimable);
+        assert!(!kind.is_immediately_usable());
+        assert!(kind.is_reclaimable_after_boot());
+    }
+
+    #[test]
+    fn mmio_is_not_reclaimable() {
+        for ty in [memory_type::MMIO, memory_type::MMIO_PORT_SPACE] {
+            let kind = MemoryRegionKind::from(ty);
+            assert_eq!(kind, MemoryRegionKind::Mmio, "type {}", ty);
+            assert!(!kind.is_immediately_usable());
+            assert!(!kind.is_reclaimable_after_boot());
+        }
+    }
+
+    #[test]
+    fn firmware_runtime_is_not_reclaimable() {
+        for ty in [
+            memory_type::RUNTIME_SERVICES_CODE,
+            memory_type::RUNTIME_SERVICES_DATA,
+        ] {
+            let kind = MemoryRegionKind::from(ty);
+            assert_eq!(kind, MemoryRegionKind::FirmwareRuntime, "type {}", ty);
+            assert!(!kind.is_reclaimable_after_boot());
+        }
+    }
+
+    #[test]
+    fn reserved_type_zero_is_reserved() {
+        let kind = MemoryRegionKind::from(memory_type::RESERVED);
+        assert_eq!(kind, MemoryRegionKind::Reserved);
+        assert!(!kind.is_immediately_usable());
+        assert!(!kind.is_reclaimable_after_boot());
+    }
+
+    #[test]
+    fn unknown_type_is_reserved() {
+        // Any type not explicitly mapped must fall through to Reserved.
+        let kind = MemoryRegionKind::from(0xFF_u32);
+        assert_eq!(kind, MemoryRegionKind::Reserved);
+    }
+
+    #[test]
+    fn region_kind_names_are_non_empty() {
+        let kinds = [
+            MemoryRegionKind::Usable,
+            MemoryRegionKind::BootloaderReclaimable,
+            MemoryRegionKind::AcpiReclaimable,
+            MemoryRegionKind::AcpiNonVolatile,
+            MemoryRegionKind::FirmwareRuntime,
+            MemoryRegionKind::Mmio,
+            MemoryRegionKind::PersistentMemory,
+            MemoryRegionKind::Unusable,
+            MemoryRegionKind::Reserved,
+        ];
+        for kind in kinds {
+            assert!(
+                !kind.name().is_empty(),
+                "{:?}.name() must not be empty",
+                kind
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // MemoryMap::parse — error paths
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_empty_map_returns_empty_error() {
+        let map = KernelMemoryMap::new();
+        assert!(matches!(MemoryMap::parse(&map), Err(ParseError::Empty)));
+    }
+
+    #[test]
+    fn parse_all_zero_page_count_returns_empty_error() {
+        // Firmware padding entries (page_count == 0) are skipped; if all
+        // entries are zero-size the result must be Empty.
+        let map = make_map(&[make_desc(memory_type::CONVENTIONAL, 0x1000, 0)]);
+        assert!(matches!(MemoryMap::parse(&map), Err(ParseError::Empty)));
+    }
+
+    #[test]
+    fn parse_unaligned_base_returns_error() {
+        // phys_start must be 4 KiB aligned (UEFI spec).
+        let map = make_map(&[make_desc(memory_type::CONVENTIONAL, 0x1001, 10)]);
+        match MemoryMap::parse(&map) {
+            Err(ParseError::UnalignedBase {
+                index: 0,
+                phys_start: 0x1001,
+            }) => {}
+            Err(e) => panic!("expected UnalignedBase(0, 0x1001), got {:?}", e),
+            Ok(_) => panic!("expected Err, got Ok"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // MemoryMap::parse — happy paths and statistics
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_single_conventional_region() {
+        let map = make_map(&[make_desc(memory_type::CONVENTIONAL, 0x1000, 100)]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        let stats = parsed.stats();
+        assert_eq!(stats.region_count, 1);
+        assert_eq!(stats.usable_bytes, 100 * 4096);
+        assert_eq!(stats.reclaimable_bytes, 0);
+        assert_eq!(stats.usable_region_count, 1);
+        assert!(!stats.is_truncated);
+    }
+
+    #[test]
+    fn parse_skips_zero_page_count_entries() {
+        let map = make_map(&[
+            make_desc(memory_type::CONVENTIONAL, 0x1000, 0), // skipped
+            make_desc(memory_type::CONVENTIONAL, 0x2000, 10), // counted
+        ]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        assert_eq!(parsed.stats().region_count, 1);
+        assert_eq!(parsed.stats().usable_bytes, 10 * 4096);
+    }
+
+    #[test]
+    fn parse_mixed_regions_computes_correct_stats() {
+        let map = make_map(&[
+            make_desc(memory_type::CONVENTIONAL, 0x0000_1000, 100), // 400 KiB usable
+            make_desc(memory_type::BOOT_SERVICES_DATA, 0x0010_0000, 50), // 200 KiB reclaimable
+            make_desc(memory_type::MMIO, 0xFEC0_0000, 4),           // excluded from RAM
+            make_desc(memory_type::RESERVED, 0x0000_F000, 1),       // not usable
+        ]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        let stats = parsed.stats();
+
+        assert_eq!(stats.region_count, 4);
+        assert_eq!(stats.usable_bytes, 100 * 4096);
+        assert_eq!(stats.reclaimable_bytes, 50 * 4096);
+        assert_eq!(stats.usable_region_count, 1);
+        // MMIO is excluded; RESERVED is included in total RAM
+        assert_eq!(stats.total_bytes, (100 + 50 + 1) * 4096);
+    }
+
+    #[test]
+    fn mmio_excluded_from_total_ram() {
+        let map = make_map(&[
+            make_desc(memory_type::CONVENTIONAL, 0x1000, 10),
+            make_desc(memory_type::MMIO, 0xFEC0_0000, 100),
+        ]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        // Only conventional counts toward total_bytes.
+        assert_eq!(parsed.stats().total_bytes, 10 * 4096);
+    }
+
+    #[test]
+    fn firmware_runtime_excluded_from_total_ram() {
+        let map = make_map(&[
+            make_desc(memory_type::CONVENTIONAL, 0x1000, 10),
+            make_desc(memory_type::RUNTIME_SERVICES_DATA, 0x10_0000, 5),
+        ]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        // Runtime services are not RAM we can use or count.
+        assert_eq!(parsed.stats().total_bytes, 10 * 4096);
+    }
+
+    #[test]
+    fn truncated_flag_propagates_to_stats() {
+        let mut map = KernelMemoryMap::new();
+        map.descriptors[0] = make_desc(memory_type::CONVENTIONAL, 0x1000, 10);
+        map.count = 1;
+        map.truncated = true;
+        let parsed = MemoryMap::parse(&map).unwrap();
+        assert!(parsed.stats().is_truncated);
+    }
+
+    #[test]
+    fn total_usable_after_boot_sums_usable_and_reclaimable() {
+        let map = make_map(&[
+            make_desc(memory_type::CONVENTIONAL, 0x1000, 100),
+            make_desc(memory_type::BOOT_SERVICES_DATA, 0x10_0000, 50),
+        ]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        let stats = parsed.stats();
+        assert_eq!(
+            stats.total_usable_after_boot(),
+            stats.usable_bytes + stats.reclaimable_bytes
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // MemoryMap query methods
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn usable_regions_returns_only_conventional() {
+        let map = make_map(&[
+            make_desc(memory_type::CONVENTIONAL, 0x1000, 10),
+            make_desc(memory_type::RESERVED, 0xF000, 1),
+            make_desc(memory_type::CONVENTIONAL, 0x10_0000, 200),
+        ]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        let usable: std::vec::Vec<_> = parsed.usable_regions().collect();
+        assert_eq!(usable.len(), 2);
+        assert!(usable.iter().all(|d| d.ty == memory_type::CONVENTIONAL));
+    }
+
+    #[test]
+    fn reclaimable_regions_includes_bootloader_and_conventional() {
+        let map = make_map(&[
+            make_desc(memory_type::CONVENTIONAL, 0x1000, 10),
+            make_desc(memory_type::BOOT_SERVICES_CODE, 0x10_0000, 5),
+            make_desc(memory_type::LOADER_DATA, 0x20_0000, 3),
+            make_desc(memory_type::MMIO, 0xFEC0_0000, 4), // excluded
+        ]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        let reclaimable: std::vec::Vec<_> = parsed.reclaimable_regions().collect();
+        assert_eq!(reclaimable.len(), 3); // CONVENTIONAL + BOOT_SERVICES_CODE + LOADER_DATA
+    }
+
+    #[test]
+    fn regions_of_type_returns_only_matching() {
+        let map = make_map(&[
+            make_desc(memory_type::CONVENTIONAL, 0x1000, 10),
+            make_desc(memory_type::MMIO, 0xFEC0_0000, 4),
+            make_desc(memory_type::CONVENTIONAL, 0x10_0000, 200),
+        ]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        let conventional: std::vec::Vec<_> =
+            parsed.regions_of_type(memory_type::CONVENTIONAL).collect();
+        assert_eq!(conventional.len(), 2);
+    }
+
+    #[test]
+    fn regions_returns_all_non_zero_entries() {
+        let map = make_map(&[
+            make_desc(memory_type::CONVENTIONAL, 0x1000, 10),
+            make_desc(memory_type::RESERVED, 0xF000, 1),
+            make_desc(memory_type::MMIO, 0xFEC0_0000, 4),
+        ]);
+        let parsed = MemoryMap::parse(&map).unwrap();
+        assert_eq!(parsed.regions().len(), 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // Large map (stress test at MAX_MEMORY_DESCRIPTORS)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_max_descriptors() {
+        let mut map = KernelMemoryMap::new();
+        for i in 0..MAX_MEMORY_DESCRIPTORS {
+            map.descriptors[i] = make_desc(memory_type::CONVENTIONAL, (i as u64 + 1) * 0x1000, 1);
+        }
+        map.count = MAX_MEMORY_DESCRIPTORS;
+        let parsed = MemoryMap::parse(&map).unwrap();
+        assert_eq!(parsed.stats().region_count, MAX_MEMORY_DESCRIPTORS);
+        assert_eq!(parsed.stats().usable_region_count, MAX_MEMORY_DESCRIPTORS);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Description

Implements Phase 1.3.1: parse the UEFI memory map handed off via KernelBootInfo and provide a kernel-side API for querying physical memory regions. This is the foundation for the Phase 1.3.2 physical memory allocator.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition or update

## Related Issues

- Closes #10

## Changes Made

### Code Changes

**`lib/boot-info/src/lib.rs`**
- Added `MemoryRegionKind` enum: classifies raw UEFI type codes into kernel-relevant buckets (`Usable`, `BootloaderReclaimable`, `AcpiReclaimable`, `FirmwareRuntime`, `Mmio`, etc.) with `is_immediately_usable()` and `is_reclaimable_after_boot()` predicates
- Added `MemoryStats` struct: caches derived statistics (`total_bytes`, `usable_bytes`, `reclaimable_bytes`, `region_count`, `usable_region_count`, `is_truncated`) computed once during parse
- Added `ParseError` enum: typed errors for `Empty` and `UnalignedBase { index, phys_start }`
- Added `MemoryMap` struct: wraps a validated copy of `KernelMemoryMap` and exposes `parse()`, `stats()`, `regions()`, `usable_regions()`, `reclaimable_regions()`, `regions_of_type(ty)`

**`kernel/src/memory/mod.rs`** (new file)
- Global `static mut MEMORY_MAP: MaybeUninit<MemoryMap>` guarded by an `AtomicBool` sentinel
- `unsafe fn init(&KernelMemoryMap) -> Result<&'static MemoryMap, ParseError>`: called once during early boot
- `fn get() -> Option<&'static MemoryMap>`: used by the allocator (Phase 1.3.2)
- Re-exports `MemoryMap`, `MemoryRegionKind`, `MemoryStats`, `ParseError` from `ferrous-boot-info`

**`kernel/src/main.rs`**
- Added `pub mod memory;`

**`boot/src/main.rs`**
- Added `print_memory_map()` called from `kernel_main` Step 5: prints each region (base, end, size, type label) and a summary line showing total/usable/reclaimable MiB
- Added helper functions `memory_type_label()`, `is_usable_after_boot()`, `is_mmio()` for the serial output

### Documentation Changes

- All public types and functions have doc comments explaining their role, usage, and safety contracts

### Testing

- 23 new tests in `ferrous-boot-info` covering all new types
- Total test count: 22 -> 45 in `ferrous-boot-info`

## ADR Requirements

- [x] This change does not require an ADR
- [x] ADR status: N/A

## Safety Considerations

- [x] This PR contains unsafe Rust code
  - Safety comments provided: Yes
  - Safety invariants documented: Yes

The `memory::init()` function uses `static mut MaybeUninit<MemoryMap>` with an `AtomicBool` guard. The safety contract (call exactly once, single-threaded, interrupts disabled) is documented on the function. After `init()` sets `INITIALIZED`, only shared references are taken via `get()`.

## Testing

- [x] Unit tests added/updated
- [x] All existing tests pass

Test categories added:
- `MemoryRegionKind` classification (8 tests): conventional, boot services, ACPI reclaim, MMIO, firmware runtime, reserved, unknown types, name labels
- `MemoryMap::parse` error paths (3 tests): empty map, all-zero page counts, non-page-aligned base
- `MemoryMap::parse` statistics (7 tests): single region, zero-size entry skipping, mixed regions, MMIO exclusion, firmware runtime exclusion, truncation flag, total-usable-after-boot sum
- Query methods (4 tests): `usable_regions`, `reclaimable_regions`, `regions_of_type`, `regions`
- Stress test (1 test): full 256-entry map

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is commented, particularly for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings generated
- [x] Tests added/updated and passing
- [x] All unsafe code has safety comments
- [x] Changes are backward compatible (or breaking changes are documented)
- [x] Commit messages follow the project's guidelines

## Additional Context

The parsing types (`MemoryMap`, `MemoryRegionKind`, etc.) live in `ferrous-boot-info` rather than the kernel crate. This is intentional: the kernel crate targets `x86_64-unknown-none` and cannot run inline tests; placing the parsing logic in `ferrous-boot-info` (a no_std lib) keeps all 45 tests runnable on the host without QEMU. The kernel `memory` module adds only the global storage layer on top.

The `print_memory_map()` function in `boot/src/main.rs` is a Phase 1 inline implementation. When the kernel becomes a separate binary in Phase 2, reporting will migrate to use the `kernel::memory` module directly.

## Reviewer Notes

- `kernel/src/memory/mod.rs`: the `#[allow(static_mut_refs)]` suppression is required by the current nightly lint; the pattern itself is safe (write-once before setting the AtomicBool, read-only after)
- `lib/boot-info/src/lib.rs`: `MemoryMap` intentionally does not derive `Debug` as the 8 KiB descriptor array makes debug output impractical; use `stats()` for diagnostics