### PR TITLE
docs: Phase 1.3.1 completion and Phase 2 planning

### DIFF
--- a/docs/MEMORY_ARCHITECTURE.md
+++ b/docs/MEMORY_ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Ferrous Kernel - Memory Management Architecture
 
-**Version:** 0.1  
-**Date:** 2026-01-04  
-**Status:** Design Phase (Phase 0)
+**Version:** 0.2
+**Date:** 2026-04-17
+**Status:** Phase 1 In Progress (1.3.1 complete, 1.3.2-1.3.5 pending)
 
 ---
 
@@ -564,30 +564,32 @@ pub enum MemoryError {
 
 ### Early Boot Sequence
 
-1. **Parse UEFI Memory Map**
-   - Identify usable memory regions
-   - Mark reserved regions (ACPI tables, bootloader data)
-   - Detect NUMA topology
+1. **Parse UEFI Memory Map** -- COMPLETE (Phase 1.3.1, PR #64)
+   - `MemoryMap::parse(&KernelMemoryMap)` validates and copies all descriptors
+   - `MemoryRegionKind` classifies each region: `Usable`, `BootloaderReclaimable`, `AcpiReclaimable`, `FirmwareRuntime`, `Mmio`, `Reserved`, etc.
+   - `MemoryStats` caches total/usable/reclaimable byte counts computed in one pass
+   - Global instance stored via `kernel::memory::init()` / `kernel::memory::get()` using `MaybeUninit` + `AtomicBool`
+   - Full region table printed to serial on every boot
 
-2. **Initialize Physical Frame Allocator**
-   - Build free frame list from memory map
-   - Reserve frames for kernel code/data
-   - Initialize per-NUMA-node allocators
+2. **Initialize Physical Frame Allocator** -- Phase 1.3.2 (pending)
+   - Build free frame bitmap from `memory::get().usable_regions()`
+   - Reserve frames for kernel code/data sections
+   - Initialize per-NUMA-node allocators (NUMA topology from ACPI SRAT, Phase 2+)
 
-3. **Set Up Kernel Page Tables**
+3. **Set Up Kernel Page Tables** -- Phase 1.3.3/1.3.4 (pending)
    - Identity map physical memory (temporary)
    - Map kernel code/data sections
    - Enable paging (CR0.PG = 1)
 
-4. **Switch to Higher-Half Kernel**
-   - Remap kernel to high virtual addresses
+4. **Switch to Higher-Half Kernel** -- Phase 1.3.3 (pending)
+   - Remap kernel to high virtual addresses (0xFFFF_8000_0000_0000+)
    - Remove low-memory identity mapping
    - Update all kernel pointers
 
-5. **Initialize Kernel Heap**
-   - Allocate initial heap frames
-   - Set up allocator data structures
-   - Enable global allocator
+5. **Initialize Kernel Heap** -- Phase 1.3.5 (pending)
+   - Allocate initial heap frames from physical allocator
+   - Set up linked-list allocator (Phase 1); migrate to buddy allocator (Phase 2)
+   - Enable `#[global_allocator]`
 
 ---
 
@@ -596,17 +598,21 @@ pub enum MemoryError {
 ### Phase 1: Foundation
 
 **Deliverables**:
-- Physical frame allocator (bitmap)
-- Basic page table management (4KB pages only)
-- Kernel heap allocator (simple linked list)
-- Address space creation/destruction
-- Higher-half kernel setup
+
+| Task | Status | Notes |
+|------|--------|-------|
+| UEFI memory map parsing | Complete (PR #64) | `MemoryMap`, `MemoryRegionKind`, `MemoryStats` in `ferrous-boot-info`; global storage in `kernel::memory` |
+| Physical frame allocator (bitmap) | Pending (1.3.2) | Consumes `memory::get().usable_regions()` |
+| Basic page table management (4 KB pages) | Pending (1.3.3/1.3.4) | x86-64 4-level PT; identity map then higher-half switch |
+| Kernel heap allocator (linked list) | Pending (1.3.5) | Implements `GlobalAlloc`; migrate to buddy in Phase 2 |
+| Higher-half kernel address space | Pending (1.3.3) | Kernel at 0xFFFF_8000_0000_0000+ |
 
 **Success Criteria**:
-- Kernel can allocate/free physical frames
-- Kernel can create page tables and map pages
-- Kernel heap allocation works
-- Boot completes with paging enabled
+- [x] UEFI memory map parsed, classified, and accessible to all kernel subsystems
+- [ ] Kernel can allocate and free physical frames
+- [ ] Kernel can create page tables and map pages
+- [ ] Kernel heap allocation works (`Box`, `Vec` available)
+- [ ] Boot completes with paging enabled
 
 ### Phase 2: Process Memory
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Ferrous Kernel - Development Roadmap
 
-**Last Updated:** 2026-03-07
+**Last Updated:** 2026-04-17
 **Status:** Phase 1 — Proof of Life (In Progress)
 
 ---
@@ -87,8 +87,11 @@ Every milestone must advance these core goals:
 - `scripts/verify-boot.sh` added — automated boot verification for CI; `docs/QEMU_TESTING.md` documents expected output and troubleshooting
 - `kernel/src/arch/x86_64/stack.rs` added — `KernelStack<N>` type with `top()`/`bottom()` and guard-region constants; 64 KiB primary stack active in `kernel_main`, bounds printed to serial
 - `kernel/src/arch/x86_64/gdt.rs` added — minimal 3-entry GDT (null, kernel-code 0x08, kernel-data 0x10); loaded via `LGDT`, CS reloaded via far-return (`RETFQ`), data segments reloaded; verified active in QEMU serial output
-- `kernel/src/arch/x86_64/idt.rs` added — 256-entry IDT with `IdtEntry`, `IdtPointer`, `ExceptionFrame` types and `unsafe load()`; 32 exception stubs (vectors 0–31) + generic IRQ stub (32–255) via `global_asm!`; `LIDT` loaded, interrupts remain disabled; verified active in QEMU serial output
-- Exception stubs upgraded — two `global_asm!` macro variants: `isr_stub` (no error code: RDI=vector, RSI=0, RDX=frame ptr) and `isr_stub_ec` (error code popped into RSI, RDX=frame ptr); `exception_handler()` prints vector name, error code (for vectors 8,10–14,17,21,29,30), faulting RIP+RFLAGS+RSP from the CPU-pushed `ExceptionFrame`, and CR2 for #PF (vector 14); boot verification passes
+- `kernel/src/arch/x86_64/idt.rs` added — 256-entry IDT with `IdtEntry`, `IdtPointer`, `ExceptionFrame` types and `unsafe load()`; 32 exception stubs (vectors 0-31) + generic IRQ stub (32-255) via `global_asm!`; `LIDT` loaded, interrupts remain disabled; verified active in QEMU serial output
+- Exception stubs upgraded — two `global_asm!` macro variants: `isr_stub` (no error code: RDI=vector, RSI=0, RDX=frame ptr) and `isr_stub_ec` (error code popped into RSI, RDX=frame ptr); `exception_handler()` prints vector name, error code (for vectors 8,10-14,17,21,29,30), faulting RIP+RFLAGS+RSP from the CPU-pushed `ExceptionFrame`, and CR2 for #PF (vector 14); boot verification passes
+- `MemoryMap`, `MemoryRegionKind`, `MemoryStats`, `ParseError` added to `ferrous-boot-info` — parses `KernelMemoryMap` from boot info, classifies UEFI memory types into kernel-relevant buckets, computes usable/reclaimable/total byte statistics; 45 host-side tests pass
+- `kernel/src/memory/mod.rs` added — global `MemoryMap` storage with `init()` / `get()` API backed by `MaybeUninit` + `AtomicBool`; Phase 1.3.2 physical allocator consumes this
+- `boot/src/main.rs` kernel_main Step 5 — prints full memory region table (base, end, size, type) and RAM summary to serial on every boot
 
 #### 1.2 - Runtime Setup
 
@@ -103,7 +106,7 @@ Every milestone must advance these core goals:
 
 | Task | Issue | Status |
 |------|-------|--------|
-| 1.3.1 Parse UEFI Memory Map | #10 | Not Started |
+| 1.3.1 Parse UEFI Memory Map | #10 | Complete (PR #64) |
 | 1.3.2 Physical Memory Allocator | #13 | Not Started |
 | 1.3.3 Virtual Memory Setup | #14 | Not Started |
 | 1.3.4 Page Table Management | #19 | Not Started |
@@ -131,45 +134,80 @@ Every milestone must advance these core goals:
 
 **Goal:** Implement fundamental kernel abstractions and user-space transition.
 
+### Architecture Decisions
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| ADR-0002 | Process Model and Task Representation | Proposed |
+| ADR-0003 | Scheduler Algorithm Selection | Proposed |
+| ADR-0004 | Capability System Data Structures | Proposed |
+| ADR-0005 | IPC Mechanism Design | Proposed |
+
 ### Milestones
 
 #### 2.1 - Process Abstractions
-- [ ] Task/process structures
-- [ ] Address space management
-- [ ] ELF loader (basic)
-- [ ] User/kernel mode switching
-- [ ] System call interface (minimal)
+
+| Task | Issue | Status | Priority |
+|------|-------|--------|----------|
+| 2.1.1 Task and Process Data Structures | — | Not Started | Critical |
+| 2.1.2 Address Space Management | — | Not Started | Critical |
+| 2.1.3 ELF Binary Loader | — | Not Started | High |
+| 2.1.4 Kernel/User Mode Transition | — | Not Started | Critical |
+| 2.1.5 System Call Interface (minimal) | — | Not Started | Critical |
+
+**Dependencies:** Phase 1.3 (memory management) must be complete.
 
 #### 2.2 - Scheduler
-- [ ] Runnable task queue
-- [ ] Basic round-robin scheduler
-- [ ] Context switching (assembly + Rust)
-- [ ] Timer interrupts (PIT/APIC)
-- [ ] Idle task
+
+| Task | Issue | Status | Priority |
+|------|-------|--------|----------|
+| 2.2.1 Runnable Task Queue | — | Not Started | Critical |
+| 2.2.2 Basic Round-Robin Scheduler | — | Not Started | Critical |
+| 2.2.3 Context Switching (assembly + Rust) | — | Not Started | Critical |
+| 2.2.4 Timer Interrupts (PIT/APIC) | — | Not Started | High |
+| 2.2.5 Idle Task | — | Not Started | High |
+
+**Dependencies:** 2.1.1 (task structures) must be complete.
 
 #### 2.3 - Capability System Foundation
-- [ ] Capability data structures
-- [ ] Capability derivation rules
-- [ ] Capability-based syscalls (grant, revoke, derive)
-- [ ] Initial capability space for processes
+
+| Task | Issue | Status | Priority |
+|------|-------|--------|----------|
+| 2.3.1 Capability Data Structures | — | Not Started | Critical |
+| 2.3.2 Capability Derivation and Delegation | — | Not Started | Critical |
+| 2.3.3 Capability-Based Syscalls (grant, revoke, derive) | — | Not Started | High |
+| 2.3.4 Initial Capability Space for Processes | — | Not Started | High |
+
+**Dependencies:** 2.1.5 (syscall interface) must be complete.
 
 #### 2.4 - IPC Primitives
-- [ ] Message passing interface design
-- [ ] Synchronous send/receive
-- [ ] Message buffer management
-- [ ] Basic endpoint addressing
+
+| Task | Issue | Status | Priority |
+|------|-------|--------|----------|
+| 2.4.1 Endpoint and Channel Data Structures | — | Not Started | Critical |
+| 2.4.2 Synchronous Send/Receive | — | Not Started | Critical |
+| 2.4.3 Message Buffer Management | — | Not Started | High |
+| 2.4.4 IPC Capability Integration | — | Not Started | High |
+
+**Dependencies:** 2.2 (scheduler) and 2.3.1 (capability structures) must be complete.
 
 #### 2.5 - First User-Space Program
-- [ ] Minimal init process
-- [ ] Syscall: exit, yield, send, receive
-- [ ] Load and execute first userspace binary
+
+| Task | Issue | Status | Priority |
+|------|-------|--------|----------|
+| 2.5.1 Minimal Init Process | — | Not Started | Critical |
+| 2.5.2 Core Syscalls (exit, yield, send, receive) | — | Not Started | Critical |
+| 2.5.3 Load and Execute First Userspace Binary | — | Not Started | Critical |
+
+**Dependencies:** 2.1 through 2.4 must be complete.
 
 ### Success Criteria
 
-- Can load and run a simple userspace program
-- Program can send/receive messages via IPC
-- Scheduler switches between multiple tasks
-- Capabilities prevent unauthorized access
+- [ ] Can load and run a simple userspace program
+- [ ] Program can send/receive messages via IPC
+- [ ] Scheduler switches between multiple tasks
+- [ ] Capabilities prevent unauthorized access
+- [ ] Kernel remains stable when a user-space task crashes
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,11 +149,11 @@ Every milestone must advance these core goals:
 
 | Task | Issue | Status | Priority |
 |------|-------|--------|----------|
-| 2.1.1 Task and Process Data Structures | — | Not Started | Critical |
-| 2.1.2 Address Space Management | — | Not Started | Critical |
-| 2.1.3 ELF Binary Loader | — | Not Started | High |
-| 2.1.4 Kernel/User Mode Transition | — | Not Started | Critical |
-| 2.1.5 System Call Interface (minimal) | — | Not Started | Critical |
+| 2.1.1 Task and Process Data Structures | #66 | Not Started | Critical |
+| 2.1.2 Address Space Management | #67 | Not Started | Critical |
+| 2.1.3 ELF Binary Loader | #68 | Not Started | High |
+| 2.1.4 Kernel/User Mode Transition | #69 | Not Started | Critical |
+| 2.1.5 System Call Interface (minimal) | #70 | Not Started | Critical |
 
 **Dependencies:** Phase 1.3 (memory management) must be complete.
 
@@ -161,11 +161,11 @@ Every milestone must advance these core goals:
 
 | Task | Issue | Status | Priority |
 |------|-------|--------|----------|
-| 2.2.1 Runnable Task Queue | — | Not Started | Critical |
-| 2.2.2 Basic Round-Robin Scheduler | — | Not Started | Critical |
-| 2.2.3 Context Switching (assembly + Rust) | — | Not Started | Critical |
-| 2.2.4 Timer Interrupts (PIT/APIC) | — | Not Started | High |
-| 2.2.5 Idle Task | — | Not Started | High |
+| 2.2.1 Runnable Task Queue | #71 | Not Started | Critical |
+| 2.2.2 Basic Round-Robin Scheduler | #72 | Not Started | Critical |
+| 2.2.3 Context Switching (assembly + Rust) | #73 | Not Started | Critical |
+| 2.2.4 Timer Interrupts (PIT/APIC) | #74 | Not Started | High |
+| 2.2.5 Idle Task | #75 | Not Started | High |
 
 **Dependencies:** 2.1.1 (task structures) must be complete.
 
@@ -173,10 +173,10 @@ Every milestone must advance these core goals:
 
 | Task | Issue | Status | Priority |
 |------|-------|--------|----------|
-| 2.3.1 Capability Data Structures | — | Not Started | Critical |
-| 2.3.2 Capability Derivation and Delegation | — | Not Started | Critical |
-| 2.3.3 Capability-Based Syscalls (grant, revoke, derive) | — | Not Started | High |
-| 2.3.4 Initial Capability Space for Processes | — | Not Started | High |
+| 2.3.1 Capability Data Structures | #76 | Not Started | Critical |
+| 2.3.2 Capability Derivation and Delegation | #77 | Not Started | Critical |
+| 2.3.3 Capability-Based Syscalls (grant, revoke, derive) | #78 | Not Started | High |
+| 2.3.4 Initial Capability Space for Processes | #79 | Not Started | High |
 
 **Dependencies:** 2.1.5 (syscall interface) must be complete.
 
@@ -184,10 +184,10 @@ Every milestone must advance these core goals:
 
 | Task | Issue | Status | Priority |
 |------|-------|--------|----------|
-| 2.4.1 Endpoint and Channel Data Structures | — | Not Started | Critical |
-| 2.4.2 Synchronous Send/Receive | — | Not Started | Critical |
-| 2.4.3 Message Buffer Management | — | Not Started | High |
-| 2.4.4 IPC Capability Integration | — | Not Started | High |
+| 2.4.1 Endpoint and Channel Data Structures | #80 | Not Started | Critical |
+| 2.4.2 Synchronous Send/Receive | #81 | Not Started | Critical |
+| 2.4.3 Message Buffer Management | #82 | Not Started | High |
+| 2.4.4 IPC Capability Integration | #83 | Not Started | High |
 
 **Dependencies:** 2.2 (scheduler) and 2.3.1 (capability structures) must be complete.
 
@@ -195,9 +195,9 @@ Every milestone must advance these core goals:
 
 | Task | Issue | Status | Priority |
 |------|-------|--------|----------|
-| 2.5.1 Minimal Init Process | — | Not Started | Critical |
-| 2.5.2 Core Syscalls (exit, yield, send, receive) | — | Not Started | Critical |
-| 2.5.3 Load and Execute First Userspace Binary | — | Not Started | Critical |
+| 2.5.1 Minimal Init Process | #84 | Not Started | Critical |
+| 2.5.2 Core Syscalls (exit, yield, send, receive) | #85 | Not Started | Critical |
+| 2.5.3 Load and Execute First Userspace Binary | #86 | Not Started | Critical |
 
 **Dependencies:** 2.1 through 2.4 must be complete.
 


### PR DESCRIPTION
## Description

Updates project documentation to reflect Phase 1.3.1 completion and expands Phase 2 planning with detailed task tables, dependency ordering, and ADR placeholders.

## Type of Change

- [x] Documentation update

## Related Issues

- Related to #10 (Phase 1.3.1 complete)

## Changes Made

### Documentation Changes

**`docs/ROADMAP.md`**
- Updated Last Updated date to 2026-04-17
- Marked 1.3.1 Parse UEFI Memory Map as Complete (PR #64)
- Added implementation notes for 1.3.1 (MemoryMap types, kernel::memory module, serial reporting)
- Expanded Phase 2 section: replaced bare bullet lists with structured task tables (issue column, status column, priority column) matching Phase 1 format
- Added dependency notes between Phase 2 milestones
- Added ADR placeholder table for Phase 2 architectural decisions
- Converted Phase 2 success criteria to trackable checkboxes

**`docs/MEMORY_ARCHITECTURE.md`**
- Updated version to 0.2, date to 2026-04-17, status to reflect Phase 1 progress
- Updated Boot-Time Memory Setup Step 1 with actual implementation details: `MemoryMap::parse()`, `MemoryRegionKind`, `MemoryStats`, `kernel::memory::init()/get()`, serial output
- Added Phase 2 and beyond notes for steps 2-5 with specific type names and crate references
- Replaced Phase 1 Foundation deliverable list with a status table showing what is complete vs pending, with task references

### Code Changes

None.

### Testing

No code changes; documentation only.

## ADR Requirements

- [x] This change does not require an ADR
- [x] ADR status: N/A

## Safety Considerations

- [x] This PR has no safety/security implications

## Testing

- [x] All existing tests pass

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [x] No new warnings generated
- [x] Commit messages follow the project's guidelines

## Reviewer Notes

Phase 2 issue numbers in the task tables are placeholders (shown as dashes). They will be filled in once the GitHub issues are created separately.