### PR TITLE
feat: Phase 1.3.2 physical frame allocator

### DIFF
--- a/boot/src/main.rs
+++ b/boot/src/main.rs
@@ -28,7 +28,7 @@ use uefi::prelude::*;
 use crate::boot_info::BootInfo;
 use crate::console::Console;
 use crate::memory::MemoryMap;
-use ferrous_boot_info::KernelBootInfo;
+use ferrous_boot_info::{BitmapFrameAllocator, KernelBootInfo, KERNEL_BITMAP_WORDS};
 
 // ---------------------------------------------------------------------------
 // Bootstrap stack
@@ -100,6 +100,22 @@ static mut KERNEL_STACK: KernelStack = KernelStack([0u8; KERNEL_STACK_SIZE]);
 /// treated as read-only by both the bootloader (during the jump) and
 /// the kernel.
 static mut KERNEL_BOOT_INFO: KernelBootInfo = KernelBootInfo::new();
+
+// ---------------------------------------------------------------------------
+// Physical frame allocator (Phase 1.3.2)
+// ---------------------------------------------------------------------------
+
+/// Global physical frame allocator for Phase 1.
+///
+/// Stores a bitmap tracking usable physical frames. The bitmap is 2 MiB and
+/// lives in BSS (zero-initialised, no binary bloat). Initialised in
+/// `kernel_main` Step 6 from the parsed `MemoryMap`.
+///
+/// SAFETY: mutated only inside `kernel_main` (single-threaded, interrupts
+/// disabled). After init, `free_frames()` and `allocate()` are called before
+/// the allocator static is returned from `kernel_main`.
+#[allow(static_mut_refs)]
+static mut FRAME_ALLOC: BitmapFrameAllocator<KERNEL_BITMAP_WORDS> = BitmapFrameAllocator::new();
 
 // ---------------------------------------------------------------------------
 // Panic handler
@@ -470,6 +486,131 @@ fn kernel_main(boot_info: &KernelBootInfo) -> ! {
     // type (Phase 1.3.1) lives in ferrous-boot-info and is accessible via
     // kernel::memory after the kernel binary is separated in Phase 2.
     print_memory_map(&boot_info.memory_map);
+
+    // -----------------------------------------------------------------------
+    // Step 6: Initialise the physical frame allocator (Phase 1.3.2).
+    //
+    // Parse the memory map into the kernel's MemoryMap type, then initialise
+    // the bitmap allocator from it.  Only immediately-usable (conventional)
+    // regions are marked free; bootloader and ACPI reclaimable regions remain
+    // reserved until a future reclamation pass (Phase 2+).
+    //
+    // We exercise the allocator with a small test sequence to prove it works:
+    //   1. Allocate 3 frames and verify distinct, page-aligned addresses.
+    //   2. Deallocate all 3 frames and confirm the free count recovers.
+    //
+    // SAFETY: single-threaded, interrupts disabled; FRAME_ALLOC is not yet
+    // initialised (total_frames == 0); no other code touches it.
+    let parsed_map = ferrous_boot_info::MemoryMap::parse(&boot_info.memory_map);
+    match parsed_map {
+        Err(_) => {
+            serial_write_str("[WARN] Frame allocator: memory map parse failed — skipping init\r\n");
+        }
+        Ok(map) => {
+            // Initialise the allocator in-place in the global static (BSS).
+            // SAFETY: FRAME_ALLOC starts all-zero (BSS), single-threaded,
+            // interrupts disabled, init called exactly once.
+            #[allow(static_mut_refs)]
+            unsafe {
+                FRAME_ALLOC.init_from_memory_map(&map);
+            }
+
+            let free = unsafe {
+                #[allow(static_mut_refs)]
+                FRAME_ALLOC.free_frames()
+            };
+            let total = unsafe {
+                #[allow(static_mut_refs)]
+                FRAME_ALLOC.total_frames()
+            };
+
+            serial_write_str("[OK] Frame allocator initialised\r\n");
+            serial_write_str("[INFO] Physical frames: ");
+            serial_write_usize(free);
+            serial_write_str(" free / ");
+            serial_write_usize(total);
+            serial_write_str(" addressable (");
+            serial_write_usize(free * 4);
+            serial_write_str(" KiB usable)\r\n");
+
+            // --- Allocator smoke test ---
+            //
+            // Allocate 3 frames; print their addresses; deallocate; verify
+            // the free count returns to the original value.
+            serial_write_str("[TEST] Allocating 3 frames...\r\n");
+            let f0 = unsafe {
+                #[allow(static_mut_refs)]
+                FRAME_ALLOC.allocate()
+            };
+            let f1 = unsafe {
+                #[allow(static_mut_refs)]
+                FRAME_ALLOC.allocate()
+            };
+            let f2 = unsafe {
+                #[allow(static_mut_refs)]
+                FRAME_ALLOC.allocate()
+            };
+
+            match (f0, f1, f2) {
+                (Some(a), Some(b), Some(c)) => {
+                    serial_write_str("[OK]   frame[0] = 0x");
+                    serial_write_usize_hex(a.start_address() as usize);
+                    serial_write_str("\r\n");
+                    serial_write_str("[OK]   frame[1] = 0x");
+                    serial_write_usize_hex(b.start_address() as usize);
+                    serial_write_str("\r\n");
+                    serial_write_str("[OK]   frame[2] = 0x");
+                    serial_write_usize_hex(c.start_address() as usize);
+                    serial_write_str("\r\n");
+
+                    // Verify all three are distinct.
+                    if a == b || b == c || a == c {
+                        serial_write_str("[FAIL] Allocator returned duplicate frames!\r\n");
+                    } else {
+                        serial_write_str("[OK]   All frames are distinct\r\n");
+                    }
+
+                    // Verify page alignment.
+                    let aligned = a.start_address() % 4096 == 0
+                        && b.start_address() % 4096 == 0
+                        && c.start_address() % 4096 == 0;
+                    if aligned {
+                        serial_write_str("[OK]   All frames are 4 KiB aligned\r\n");
+                    } else {
+                        serial_write_str("[FAIL] Frame address is not page-aligned!\r\n");
+                    }
+
+                    // Return all three frames and verify count recovers.
+                    let free_before_dealloc = unsafe {
+                        #[allow(static_mut_refs)]
+                        FRAME_ALLOC.free_frames()
+                    };
+                    unsafe {
+                        #[allow(static_mut_refs)]
+                        FRAME_ALLOC.deallocate(a);
+                        #[allow(static_mut_refs)]
+                        FRAME_ALLOC.deallocate(b);
+                        #[allow(static_mut_refs)]
+                        FRAME_ALLOC.deallocate(c);
+                    }
+                    let free_after_dealloc = unsafe {
+                        #[allow(static_mut_refs)]
+                        FRAME_ALLOC.free_frames()
+                    };
+                    if free_after_dealloc == free_before_dealloc + 3 {
+                        serial_write_str("[OK]   Deallocation restored free count (+3)\r\n");
+                    } else {
+                        serial_write_str("[FAIL] Free count after dealloc is wrong!\r\n");
+                    }
+                }
+                _ => {
+                    serial_write_str(
+                        "[WARN] Fewer than 3 usable frames available — smoke test skipped\r\n",
+                    );
+                }
+            }
+        }
+    }
 
     if boot_info.acpi_rsdp != 0 {
         serial_write_str("[INFO] ACPI RSDP: 0x");

--- a/docs/MEMORY_ARCHITECTURE.md
+++ b/docs/MEMORY_ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Ferrous Kernel - Memory Management Architecture
 
-**Version:** 0.2
-**Date:** 2026-04-17
-**Status:** Phase 1 In Progress (1.3.1 complete, 1.3.2-1.3.5 pending)
+**Version:** 0.3
+**Date:** 2026-05-01
+**Status:** Phase 1 In Progress (1.3.1 and 1.3.2 complete, 1.3.3-1.3.5 pending)
 
 ---
 
@@ -64,82 +64,88 @@ Ferrous uses a **higher-half kernel** design with separate kernel and user addre
 
 ### Physical Memory
 
-#### PhysicalFrame
+#### PhysFrame
 
-A physical memory frame (4KB page on x86_64). Physical frames are allocated from a global frame allocator.
+A physical memory frame handle (4 KiB page on x86_64), implemented in `ferrous-boot-info` so it can be unit-tested on the host.
 
 **Key Properties**:
-- Owned type (RAII) - automatically freed when dropped
-- Cannot be cloned or copied (unique ownership)
-- Frame number (PFN) is the identifier
-- All frame operations are unsafe (raw pointer manipulation)
+- Wraps a physical frame number (PFN): `start_address == pfn * 4096`
+- `Copy` in Phase 1 — no `Drop`/RAII because implementing `Drop` with automatic deallocation would create a circular dependency (`ferrous-boot-info` cannot call into `kernel`). Phase 2 will remove `Copy` and add `Drop`-based deallocation once the kernel crate has its own test infrastructure.
+- Constructors validate alignment; `from_pfn` is `#[doc(hidden)]` (allocator-internal use only)
 
-**Rust Interface (conceptual)**:
+**Actual API** (`ferrous-boot-info::PhysFrame`):
 ```rust
-pub struct PhysicalFrame {
-    pfn: PhysicalFrameNumber,
-    // ...
-}
+pub const PAGE_SIZE: u64 = 4096;
 
-impl PhysicalFrame {
-    /// Allocate a new physical frame
-    pub fn allocate() -> Option<Self> { /* ... */ }
-    
-    /// Get the frame number
-    pub fn pfn(&self) -> PhysicalFrameNumber { /* ... */ }
-    
-    /// Get physical address
-    pub fn start_address(&self) -> PhysicalAddress { /* ... */ }
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PhysFrame(u64); // inner = PFN
 
-// Automatic deallocation via Drop trait
-impl Drop for PhysicalFrame {
-    fn drop(&mut self) {
-        // Return frame to allocator
-    }
+impl PhysFrame {
+    pub fn from_addr(phys_addr: u64) -> Option<Self>; // None if not 4 KiB aligned
+    pub fn pfn(self) -> u64;
+    pub fn start_address(self) -> u64; // pfn * PAGE_SIZE
+    pub fn end_address(self) -> u64;   // (pfn + 1) * PAGE_SIZE
 }
 ```
 
-#### PhysicalFrameAllocator
+#### BitmapFrameAllocator
 
-Manages allocation and deallocation of physical frames.
+Phase 1 physical frame allocator. Tracks frame availability with a fixed-size bitmap stored entirely in BSS.
 
-**Allocation Strategy Options**:
-- **Buddy Allocator**: Good for power-of-2 allocations, moderate fragmentation
-- **Bitmap Allocator**: Simple, predictable, good for small systems
-- **Slab Allocator**: Efficient for fixed-size allocations
+**Design decisions**:
+- **Bitmap allocator** chosen for Phase 1: simple, predictable, O(WORDS) worst-case, O(1) amortised with hint
+- **Bit 1 = free, bit 0 = reserved/allocated** — BSS zero-init safely means "all frames reserved" before `init_from_memory_map` runs
+- **`const fn new()` returns all-zeros** — 2 MiB static lands in BSS, not the data segment; zero binary bloat
+- **Const-generic `WORDS`** — small test instances in `ferrous-boot-info` unit tests; 2 MiB production instance in `kernel`
+- **First-fit with word-level hint** — `next_hint` word index skips already-exhausted words; sequential allocations are O(1) in practice
+- Phase 1 allocates **only from immediately-usable (conventional) regions**; reclaimable regions (bootloader, ACPI) reclaimed in Phase 2+
+- **No internal synchronisation** — Phase 1 is single-core with interrupts disabled during all allocator calls; Phase 2 adds spinlock
 
-**Phase 1 Decision**: Start with bitmap allocator for simplicity, migrate to buddy allocator if needed.
-
-**NUMA Support**:
-- Allocator maintains per-NUMA-node free lists
-- Allocation prefers local NUMA node
-- Fallback to remote nodes if local is exhausted
-
-**Rust Interface (conceptual)**:
+**Actual API** (`ferrous-boot-info::BitmapFrameAllocator<const WORDS: usize>`):
 ```rust
-pub struct PhysicalFrameAllocator {
-    // Per-NUMA-node allocators
-    nodes: Vec<NodeAllocator>,
-    // ...
-}
+pub const KERNEL_BITMAP_WORDS: usize = 262_144; // supports 64 GiB
 
-impl PhysicalFrameAllocator {
-    /// Initialize from UEFI memory map
-    pub fn from_uefi_memory_map(map: &MemoryMap) -> Result<Self, MemoryError> {
-        // Parse memory map, mark reserved regions
-        // Initialize per-node allocators
-    }
-    
-    /// Allocate a frame, preferring local NUMA node
-    pub fn allocate_frame(&mut self) -> Option<PhysicalFrame> { /* ... */ }
-    
-    /// Allocate from specific NUMA node
-    pub fn allocate_frame_from_node(&mut self, node: NumaNode) -> Option<PhysicalFrame> {
-        /* ... */
-    }
+pub struct BitmapFrameAllocator<const WORDS: usize> { /* bitmap + metadata */ }
+
+impl<const WORDS: usize> BitmapFrameAllocator<WORDS> {
+    pub const fn new() -> Self;                              // all-zeros, BSS-safe
+    pub fn init_from_memory_map(&mut self, map: &MemoryMap); // mark usable frames free
+    pub fn mark_reserved(&mut self, phys_start: u64, size_bytes: u64);
+    pub fn allocate(&mut self) -> Option<PhysFrame>;         // first-fit with hint
+    pub fn deallocate(&mut self, frame: PhysFrame);          // double-free detected in debug
+    pub fn free_frames(&self) -> usize;
+    pub fn total_frames(&self) -> usize;                     // WORDS * 64
+    pub fn allocated_frames(&self) -> usize;
 }
 ```
+
+**Global kernel instance** (`kernel::memory::frame_allocator`):
+```rust
+// 2 MiB in BSS — zero binary overhead.
+static mut ALLOCATOR: BitmapFrameAllocator<KERNEL_BITMAP_WORDS> = BitmapFrameAllocator::new();
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+// Public API (unsafe — callers guarantee single-threaded access in Phase 1):
+pub unsafe fn init(map: &MemoryMap);
+pub unsafe fn allocate() -> Option<PhysFrame>;
+pub unsafe fn deallocate(frame: PhysFrame);
+pub unsafe fn mark_reserved(phys_start: u64, size_bytes: u64);
+
+// Safe stat queries:
+pub fn free_frames() -> Option<usize>;
+pub fn total_frames() -> Option<usize>;
+pub fn allocated_frames() -> Option<usize>;
+```
+
+**QEMU measurements** (Phase 1.3.2, PR #87):
+- 52,311 free frames (204 MiB immediately usable)
+- 16,777,216 total addressable frames (64 GiB bitmap capacity)
+- Smoke test: 3 allocations returned distinct, 4 KiB-aligned addresses; deallocation restored count
+
+**NUMA Support** (Phase 2+):
+- Phase 1 uses a single global bitmap
+- Phase 2+ will parse ACPI SRAT to build per-NUMA-node allocators
+- Allocation will prefer the local NUMA node with fallback to remote nodes
 
 ### Virtual Memory
 
@@ -482,10 +488,10 @@ Every unsafe block modifying page tables must document:
 - Prevents data races (borrow checker)
 - Clear lifetime semantics
 
-**PhysicalFrame Ownership**:
-- `PhysicalFrame` is owned (cannot be cloned)
-- Dropping a `PhysicalFrame` returns it to allocator
-- Moving frames between address spaces transfers ownership
+**PhysFrame Ownership (Phase 1)**:
+- `PhysFrame` is `Copy` in Phase 1 — no `Drop` because `ferrous-boot-info` cannot call into `kernel`
+- Callers explicitly invoke `frame_allocator::deallocate(frame)` when done
+- Phase 2 removes `Copy` and adds `Drop`-based automatic deallocation once the allocator moves into the kernel crate
 
 **PageTable Ownership**:
 - `AddressSpace` owns its `PageTable`
@@ -571,10 +577,12 @@ pub enum MemoryError {
    - Global instance stored via `kernel::memory::init()` / `kernel::memory::get()` using `MaybeUninit` + `AtomicBool`
    - Full region table printed to serial on every boot
 
-2. **Initialize Physical Frame Allocator** -- Phase 1.3.2 (pending)
-   - Build free frame bitmap from `memory::get().usable_regions()`
-   - Reserve frames for kernel code/data sections
-   - Initialize per-NUMA-node allocators (NUMA topology from ACPI SRAT, Phase 2+)
+2. **Initialize Physical Frame Allocator** -- COMPLETE (Phase 1.3.2, PR #87)
+   - `PhysFrame` and `BitmapFrameAllocator<const WORDS>` implemented in `ferrous-boot-info` (host-testable); 25 new unit tests (70 total)
+   - `kernel::memory::frame_allocator` holds a 2 MiB `static mut BitmapFrameAllocator<262144>` in BSS (zero binary bloat)
+   - `init_from_memory_map` marks immediately-usable (conventional) regions free; reclaimable regions remain reserved until Phase 2+ reclamation pass
+   - Phase 1 threading: single-core, interrupts disabled; `unsafe` API; Phase 2 adds spinlock
+   - QEMU boot output confirms 52,311 free frames / 204 MiB usable; 3-frame smoke test passes
 
 3. **Set Up Kernel Page Tables** -- Phase 1.3.3/1.3.4 (pending)
    - Identity map physical memory (temporary)
@@ -601,15 +609,15 @@ pub enum MemoryError {
 
 | Task | Status | Notes |
 |------|--------|-------|
-| UEFI memory map parsing | Complete (PR #64) | `MemoryMap`, `MemoryRegionKind`, `MemoryStats` in `ferrous-boot-info`; global storage in `kernel::memory` |
-| Physical frame allocator (bitmap) | Pending (1.3.2) | Consumes `memory::get().usable_regions()` |
+| UEFI memory map parsing | Complete (PR #64) | `MemoryMap`, `MemoryRegionKind`, `MemoryStats` in `ferrous-boot-info`; global `init`/`get` in `kernel::memory` |
+| Physical frame allocator (bitmap) | Complete (PR #87) | `BitmapFrameAllocator<262144>` in `ferrous-boot-info`; 2 MiB BSS bitmap; 52,311 free frames on QEMU |
 | Basic page table management (4 KB pages) | Pending (1.3.3/1.3.4) | x86-64 4-level PT; identity map then higher-half switch |
 | Kernel heap allocator (linked list) | Pending (1.3.5) | Implements `GlobalAlloc`; migrate to buddy in Phase 2 |
 | Higher-half kernel address space | Pending (1.3.3) | Kernel at 0xFFFF_8000_0000_0000+ |
 
 **Success Criteria**:
 - [x] UEFI memory map parsed, classified, and accessible to all kernel subsystems
-- [ ] Kernel can allocate and free physical frames
+- [x] Kernel can allocate and free physical frames
 - [ ] Kernel can create page tables and map pages
 - [ ] Kernel heap allocation works (`Box`, `Vec` available)
 - [ ] Boot completes with paging enabled

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Ferrous Kernel - Development Roadmap
 
-**Last Updated:** 2026-04-17
+**Last Updated:** 2026-05-01
 **Status:** Phase 1 — Proof of Life (In Progress)
 
 ---
@@ -90,8 +90,11 @@ Every milestone must advance these core goals:
 - `kernel/src/arch/x86_64/idt.rs` added — 256-entry IDT with `IdtEntry`, `IdtPointer`, `ExceptionFrame` types and `unsafe load()`; 32 exception stubs (vectors 0-31) + generic IRQ stub (32-255) via `global_asm!`; `LIDT` loaded, interrupts remain disabled; verified active in QEMU serial output
 - Exception stubs upgraded — two `global_asm!` macro variants: `isr_stub` (no error code: RDI=vector, RSI=0, RDX=frame ptr) and `isr_stub_ec` (error code popped into RSI, RDX=frame ptr); `exception_handler()` prints vector name, error code (for vectors 8,10-14,17,21,29,30), faulting RIP+RFLAGS+RSP from the CPU-pushed `ExceptionFrame`, and CR2 for #PF (vector 14); boot verification passes
 - `MemoryMap`, `MemoryRegionKind`, `MemoryStats`, `ParseError` added to `ferrous-boot-info` — parses `KernelMemoryMap` from boot info, classifies UEFI memory types into kernel-relevant buckets, computes usable/reclaimable/total byte statistics; 45 host-side tests pass
-- `kernel/src/memory/mod.rs` added — global `MemoryMap` storage with `init()` / `get()` API backed by `MaybeUninit` + `AtomicBool`; Phase 1.3.2 physical allocator consumes this
+- `kernel/src/memory/mod.rs` added — global `MemoryMap` storage with `init()` / `get()` API backed by `MaybeUninit` + `AtomicBool`
 - `boot/src/main.rs` kernel_main Step 5 — prints full memory region table (base, end, size, type) and RAM summary to serial on every boot
+- `PhysFrame` and `BitmapFrameAllocator<const WORDS>` added to `ferrous-boot-info` — bitmap allocator (bit=1 free, bit=0 reserved); `const fn new()` produces all-zeros (BSS-safe); `init_from_memory_map` marks conventional regions free; O(1) amortised allocation with word-level hint; double-free detection in debug builds; 25 new host-side tests (70 total)
+- `kernel/src/memory/frame_allocator.rs` added — 2 MiB `static mut BitmapFrameAllocator<262144>` (64 GiB capacity, lives in BSS); `AtomicBool` init guard with Release/Acquire ordering; `unsafe` `init`, `allocate`, `deallocate`, `mark_reserved` API; safe stat queries `free_frames()`, `total_frames()`, `allocated_frames()`
+- `boot/src/main.rs` kernel_main Step 6 — initialises frame allocator, prints free/total frame counts and usable KiB, runs 3-frame smoke test (allocate, verify distinct + 4 KiB aligned, deallocate, verify count recovery); confirmed on QEMU (52,311 free frames / 204 MiB usable)
 
 #### 1.2 - Runtime Setup
 
@@ -107,7 +110,7 @@ Every milestone must advance these core goals:
 | Task | Issue | Status |
 |------|-------|--------|
 | 1.3.1 Parse UEFI Memory Map | #10 | Complete (PR #64) |
-| 1.3.2 Physical Memory Allocator | #13 | Not Started |
+| 1.3.2 Physical Memory Allocator | #13 | Complete (PR #87) |
 | 1.3.3 Virtual Memory Setup | #14 | Not Started |
 | 1.3.4 Page Table Management | #19 | Not Started |
 | 1.3.5 Kernel Heap Allocator | #20 | Not Started |

--- a/kernel/src/memory/frame_allocator.rs
+++ b/kernel/src/memory/frame_allocator.rs
@@ -1,0 +1,189 @@
+//! Global physical frame allocator.
+//!
+//! Wraps [`BitmapFrameAllocator`] in a static storage instance guarded by an
+//! `AtomicBool` initialisation sentinel.
+//!
+//! # Threading model (Phase 1)
+//!
+//! The kernel runs single-core with interrupts disabled during all allocator
+//! calls. The `unsafe` functions below rely on the caller honouring this
+//! contract. Phase 2 will replace the bare `static mut` access with a
+//! spinlock-protected wrapper.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! // In kernel_main, after memory::init():
+//! // SAFETY: called once, single-threaded, interrupts disabled.
+//! unsafe { frame_allocator::init(memory_map) };
+//!
+//! // Anywhere after init():
+//! let frame = unsafe { frame_allocator::allocate() }.expect("out of physical memory");
+//! // ... use frame ...
+//! unsafe { frame_allocator::deallocate(frame) };
+//! ```
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use ferrous_boot_info::{BitmapFrameAllocator, KERNEL_BITMAP_WORDS};
+
+pub use ferrous_boot_info::{PhysFrame, PAGE_SIZE};
+
+use super::MemoryMap;
+
+// ---------------------------------------------------------------------------
+// Global allocator instance
+// ---------------------------------------------------------------------------
+
+/// Sentinel: `true` after [`init`] completes successfully.
+///
+/// `Ordering::Release` on store / `Ordering::Acquire` on load ensures all
+/// bitmap writes in `init` are visible to any reader that observes
+/// `INITIALIZED == true`.
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+/// The kernel's physical frame allocator.
+///
+/// Stored as a `static mut` rather than `MaybeUninit` because
+/// `BitmapFrameAllocator::new()` is `const fn` and produces an all-zero
+/// value that matches BSS zero-initialisation. The 2 MiB bitmap therefore
+/// lives in BSS and does not bloat the binary image.
+///
+/// # SAFETY invariant
+///
+/// - Before `INITIALIZED` is `true`: only [`init`] may mutate this.
+/// - After `INITIALIZED` is `true`: only [`allocate`] and [`deallocate`]
+///   may mutate this; callers guarantee single-threaded access.
+#[allow(static_mut_refs)]
+static mut ALLOCATOR: BitmapFrameAllocator<KERNEL_BITMAP_WORDS> = BitmapFrameAllocator::new();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the allocator has been initialised.
+#[inline]
+pub fn is_initialized() -> bool {
+    INITIALIZED.load(Ordering::Acquire)
+}
+
+/// Initialise the global frame allocator from the parsed memory map.
+///
+/// Marks all immediately-usable (conventional) physical frames as free.
+/// Reclaimable regions (bootloader code/data, ACPI tables) remain reserved
+/// until a future reclamation pass (Phase 2+).
+///
+/// # Safety
+///
+/// - Must be called **exactly once**.
+/// - Must be called **after** `memory::init()`.
+/// - Must be called from a **single-threaded context** with interrupts disabled
+///   (the standard early-boot environment).
+///
+/// Violating any of these invariants is undefined behaviour.
+pub unsafe fn init(map: &MemoryMap) {
+    debug_assert!(
+        !INITIALIZED.load(Ordering::Relaxed),
+        "frame_allocator::init() called more than once"
+    );
+
+    // SAFETY: single-threaded, interrupts disabled, INITIALIZED is still false
+    // so no concurrent reader exists.
+    #[allow(static_mut_refs)]
+    ALLOCATOR.init_from_memory_map(map);
+
+    // Release store: all writes to ALLOCATOR are visible after this.
+    INITIALIZED.store(true, Ordering::Release);
+}
+
+/// Allocates a single 4 KiB physical frame.
+///
+/// Returns `None` if all usable frames are exhausted (out-of-memory).
+///
+/// # Safety
+///
+/// - [`init`] must have been called before the first allocation.
+/// - Must be called from a single-threaded context with interrupts disabled
+///   (Phase 1 invariant; Phase 2 will add spinlock protection).
+pub unsafe fn allocate() -> Option<PhysFrame> {
+    debug_assert!(
+        INITIALIZED.load(Ordering::Relaxed),
+        "frame_allocator::allocate() called before init()"
+    );
+    // SAFETY: INITIALIZED guarantees init() ran. Caller guarantees single-
+    // threaded access.
+    #[allow(static_mut_refs)]
+    ALLOCATOR.allocate()
+}
+
+/// Returns a physical frame to the free pool.
+///
+/// # Safety
+///
+/// - [`init`] must have been called.
+/// - `frame` must have been obtained from a prior call to [`allocate`] and
+///   must not have been deallocated already (no double-free).
+/// - Must be called from a single-threaded context with interrupts disabled
+///   (Phase 1 invariant).
+pub unsafe fn deallocate(frame: PhysFrame) {
+    debug_assert!(
+        INITIALIZED.load(Ordering::Relaxed),
+        "frame_allocator::deallocate() called before init()"
+    );
+    // SAFETY: see allocate().
+    #[allow(static_mut_refs)]
+    ALLOCATOR.deallocate(frame);
+}
+
+/// Marks a physical address range as reserved, removing any free frames in
+/// that range from the allocation pool.
+///
+/// Safe to call after `init` to protect regions that were initially marked
+/// usable but should not be allocated (e.g., the kernel image if it resides
+/// in conventional memory).
+///
+/// # Safety
+///
+/// - [`init`] must have been called.
+/// - Must be called from a single-threaded context with interrupts disabled.
+pub unsafe fn mark_reserved(phys_start: u64, size_bytes: u64) {
+    debug_assert!(
+        INITIALIZED.load(Ordering::Relaxed),
+        "frame_allocator::mark_reserved() called before init()"
+    );
+    #[allow(static_mut_refs)]
+    ALLOCATOR.mark_reserved(phys_start, size_bytes);
+}
+
+/// Returns the number of free physical frames, or `None` if not initialised.
+pub fn free_frames() -> Option<usize> {
+    if INITIALIZED.load(Ordering::Acquire) {
+        // SAFETY: INITIALIZED guarantees ALLOCATOR is fully initialised and
+        // we only take a shared reference (read-only).
+        #[allow(static_mut_refs)]
+        Some(unsafe { ALLOCATOR.free_frames() })
+    } else {
+        None
+    }
+}
+
+/// Returns the total number of frames the allocator tracks (`KERNEL_BITMAP_WORDS * 64`),
+/// or `None` if not initialised.
+pub fn total_frames() -> Option<usize> {
+    if INITIALIZED.load(Ordering::Acquire) {
+        #[allow(static_mut_refs)]
+        Some(unsafe { ALLOCATOR.total_frames() })
+    } else {
+        None
+    }
+}
+
+/// Returns the number of allocated frames, or `None` if not initialised.
+pub fn allocated_frames() -> Option<usize> {
+    if INITIALIZED.load(Ordering::Acquire) {
+        #[allow(static_mut_refs)]
+        Some(unsafe { ALLOCATOR.allocated_frames() })
+    } else {
+        None
+    }
+}

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -1,25 +1,26 @@
 //! Physical memory management subsystem.
 //!
 //! This module provides the kernel's authoritative view of physical memory,
-//! parsed from the bootloader-provided [`KernelMemoryMap`] at startup.
+//! parsed from the bootloader-provided [`KernelMemoryMap`] at startup,
+//! and manages a global physical frame allocator.
 //!
-//! # Usage
+//! # Initialisation sequence
 //!
-//! During early kernel initialisation (before the allocator runs), call
-//! [`init`] exactly once with the memory map from [`KernelBootInfo`]:
+//! Call both init functions exactly once during early boot, in order:
 //!
 //! ```ignore
+//! // Step 1: Parse and store the memory map.
 //! // SAFETY: called once, single-threaded, interrupts disabled.
 //! let map = unsafe { memory::init(&boot_info.memory_map) }
 //!     .expect("memory map parse failed");
+//!
+//! // Step 2: Initialise the physical frame allocator.
+//! // SAFETY: called once, after memory::init(), interrupts disabled.
+//! unsafe { memory::frame_allocator::init(map) };
 //! ```
 //!
-//! Thereafter any kernel subsystem can call [`get`] to borrow the map:
-//!
-//! ```ignore
-//! let map = memory::get().expect("memory not initialised");
-//! for region in map.usable_regions() { ... }
-//! ```
+//! Thereafter any kernel subsystem can call [`get`] to borrow the map or
+//! use [`frame_allocator::allocate`] to obtain physical frames.
 //!
 //! # Re-exports
 //!
@@ -27,6 +28,8 @@
 //! [`ParseError`]) live in [`ferrous_boot_info`] so they can be tested on the
 //! host without targeting `x86_64-unknown-none`. They are re-exported here
 //! for ergonomic access within the kernel.
+
+pub mod frame_allocator;
 
 use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicBool, Ordering};

--- a/lib/boot-info/src/lib.rs
+++ b/lib/boot-info/src/lib.rs
@@ -496,6 +496,359 @@ impl MemoryMap {
 }
 
 // ---------------------------------------------------------------------------
+// Physical frame tracking and bitmap allocator
+//
+// These types live here (rather than in the kernel crate) because they
+// operate purely on `MemoryMap` data and can be unit-tested on the host
+// without targeting x86_64-unknown-none. The kernel's
+// `memory::frame_allocator` module adds global static storage on top of
+// these types.
+//
+// Migration note: will move to `lib/memory` once the kernel crate has its
+// own test infrastructure (Phase 2+).
+// ---------------------------------------------------------------------------
+
+/// Physical page size on x86_64: 4 KiB.
+pub const PAGE_SIZE: u64 = 4096;
+
+/// Number of `u64` words in the kernel's physical frame allocator bitmap.
+///
+/// Each word tracks 64 frames (4 KiB each), so this value supports up to
+/// `KERNEL_BITMAP_WORDS * 64 * 4096` bytes of physical RAM = 64 GiB.
+///
+/// The bitmap lives in kernel BSS (zero-initialised); it does not bloat the
+/// kernel binary image. Increase if the target system exceeds 64 GiB.
+pub const KERNEL_BITMAP_WORDS: usize = 262_144; // 64 GiB / 4 KiB / 64
+
+/// A physical memory frame handle.
+///
+/// Wraps a physical frame number (PFN): `start_address == pfn * PAGE_SIZE`.
+///
+/// # Phase 1 note
+///
+/// This type is [`Copy`] in Phase 1 because there is no `Drop` implementation
+/// for automatic deallocation — callers explicitly invoke
+/// `frame_allocator::deallocate()`. Phase 2 will introduce RAII deallocation
+/// and remove `Copy` to enforce unique ownership.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PhysFrame(u64);
+
+impl PhysFrame {
+    /// Construct a frame handle from a page-aligned physical address.
+    ///
+    /// Returns `None` if `phys_addr` is not [`PAGE_SIZE`]-aligned.
+    #[inline]
+    pub fn from_addr(phys_addr: u64) -> Option<Self> {
+        if phys_addr % PAGE_SIZE == 0 {
+            Some(Self(phys_addr / PAGE_SIZE))
+        } else {
+            None
+        }
+    }
+
+    /// Construct a frame handle directly from a physical frame number (PFN).
+    ///
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring `pfn` corresponds to a valid,
+    /// allocated physical frame. This constructor is intended for use inside
+    /// the frame allocator only.
+    #[doc(hidden)]
+    #[inline]
+    pub fn from_pfn(pfn: u64) -> Self {
+        Self(pfn)
+    }
+
+    /// Returns the physical frame number (PFN).
+    #[inline]
+    pub fn pfn(self) -> u64 {
+        self.0
+    }
+
+    /// Returns the physical start address of this frame.
+    #[inline]
+    pub fn start_address(self) -> u64 {
+        self.0 * PAGE_SIZE
+    }
+
+    /// Returns the physical end address (exclusive) of this frame.
+    #[inline]
+    pub fn end_address(self) -> u64 {
+        (self.0 + 1) * PAGE_SIZE
+    }
+}
+
+/// Bitmap physical frame allocator.
+///
+/// Tracks physical frame availability using a fixed-size bitmap. Each bit
+/// represents one 4 KiB physical page frame:
+///
+/// - **bit = 1**: frame is free and available for allocation.
+/// - **bit = 0**: frame is reserved, allocated, or outside usable RAM.
+///
+/// The all-zeros initial state (matching BSS zero-initialisation) means
+/// "all frames reserved", which is the safe starting point:
+/// [`init_from_memory_map`][Self::init_from_memory_map] explicitly marks
+/// usable regions free before any allocation can occur.
+///
+/// # Generic parameter
+///
+/// `WORDS` is the number of `u64` bitmap words, controlling the maximum
+/// number of physical frames tracked (`WORDS * 64`). Use
+/// [`KERNEL_BITMAP_WORDS`] for the production kernel instance.
+///
+/// # Threading model
+///
+/// The allocator contains **no internal synchronisation**. In Phase 1 the
+/// kernel runs single-core with interrupts disabled during allocation. Callers
+/// are responsible for ensuring mutual exclusion. Phase 2 will wrap this type
+/// in a spinlock.
+pub struct BitmapFrameAllocator<const WORDS: usize> {
+    /// Bitmap: each bit represents one frame.
+    /// 1 = free (available), 0 = allocated or reserved.
+    bitmap: [u64; WORDS],
+    /// Total frames this allocator can address (`WORDS * 64`).
+    /// Set by `init_from_memory_map`; 0 before initialisation.
+    total_frames: usize,
+    /// Count of frames with bit = 1 (free). Maintained incrementally to
+    /// avoid a full bitmap scan on every allocation.
+    free_frames: usize,
+    /// Word-index hint for the next allocation search.
+    /// Reduces average scan cost by skipping already-exhausted words.
+    next_hint: usize,
+}
+
+impl<const WORDS: usize> core::fmt::Debug for BitmapFrameAllocator<WORDS> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BitmapFrameAllocator")
+            .field("bitmap_words", &WORDS)
+            .field("total_frames", &self.total_frames)
+            .field("free_frames", &self.free_frames)
+            .field("allocated_frames", &self.allocated_frames())
+            .finish()
+    }
+}
+
+impl<const WORDS: usize> BitmapFrameAllocator<WORDS> {
+    // -----------------------------------------------------------------------
+    // Construction
+    // -----------------------------------------------------------------------
+
+    /// Creates a new allocator in the "all reserved" state.
+    ///
+    /// The bitmap is entirely zero (all frames reserved). Call
+    /// [`init_from_memory_map`][Self::init_from_memory_map] before making
+    /// any allocations.
+    ///
+    /// This function is `const` so it can be used in static initialisers.
+    /// The resulting all-zero layout matches BSS zero-initialisation, meaning
+    /// `static mut ALLOC: BitmapFrameAllocator<N> = BitmapFrameAllocator::new()`
+    /// does not bloat the binary image.
+    pub const fn new() -> Self {
+        Self {
+            bitmap: [0u64; WORDS],
+            total_frames: 0,
+            free_frames: 0,
+            next_hint: 0,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Initialisation
+    // -----------------------------------------------------------------------
+
+    /// Initialise the allocator from a parsed memory map.
+    ///
+    /// Marks all **immediately-usable** (conventional) memory regions as free.
+    /// Reclaimable regions (bootloader, ACPI) remain reserved and will be
+    /// reclaimed in a later pass (Phase 2+).
+    ///
+    /// `total_frames` is set to `WORDS * 64` regardless of how much physical
+    /// RAM exists; frames beyond the last usable region remain 0 (reserved)
+    /// and are never returned by [`allocate`][Self::allocate].
+    ///
+    /// # Panics (debug builds only)
+    ///
+    /// Asserts that `total_frames == 0` before initialisation to catch
+    /// double-init bugs.
+    pub fn init_from_memory_map(&mut self, map: &MemoryMap) {
+        debug_assert_eq!(
+            self.total_frames, 0,
+            "init_from_memory_map() called more than once"
+        );
+
+        self.total_frames = WORDS * 64;
+
+        // Mark all immediately-usable (conventional) regions as free.
+        for region in map.usable_regions() {
+            let start_pfn = (region.phys_start / PAGE_SIZE) as usize;
+            let end_pfn = start_pfn + region.page_count as usize;
+            self.set_range_free(start_pfn, end_pfn);
+        }
+
+        // Derive free_frames by counting set bits (one accurate pass at init).
+        self.free_frames = self.count_free_in_bitmap();
+        self.next_hint = 0;
+    }
+
+    /// Marks all frames in the physical range `[phys_start, phys_start + size_bytes)`
+    /// as reserved (unavailable for allocation).
+    ///
+    /// Useful for protecting the kernel image, ACPI tables, or device memory
+    /// after `init_from_memory_map` has run. Frames are page-aligned outward.
+    /// Frames already reserved are left unchanged.
+    pub fn mark_reserved(&mut self, phys_start: u64, size_bytes: u64) {
+        if size_bytes == 0 {
+            return;
+        }
+        let start_pfn = (phys_start / PAGE_SIZE) as usize;
+        // Round up to next page boundary.
+        let end_pfn = ((phys_start + size_bytes + PAGE_SIZE - 1) / PAGE_SIZE) as usize;
+
+        for pfn in start_pfn..end_pfn {
+            let word = pfn / 64;
+            let bit = pfn % 64;
+            if word < WORDS {
+                let mask = 1u64 << bit;
+                if self.bitmap[word] & mask != 0 {
+                    // Frame was free — removing it from the pool.
+                    self.bitmap[word] &= !mask;
+                    self.free_frames = self.free_frames.saturating_sub(1);
+                }
+            }
+        }
+
+        // Rewind hint in case we just reserved frames before it.
+        let hint_candidate = start_pfn / 64;
+        if hint_candidate < self.next_hint {
+            self.next_hint = hint_candidate;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Allocation / deallocation
+    // -----------------------------------------------------------------------
+
+    /// Allocates a single physical frame using a first-fit strategy.
+    ///
+    /// The search begins at [`next_hint`] (the word containing the last
+    /// allocation) and wraps around if needed, so sequential allocations are
+    /// O(1) amortised.
+    ///
+    /// Returns `None` if no free frames are available.
+    pub fn allocate(&mut self) -> Option<PhysFrame> {
+        if self.free_frames == 0 {
+            return None;
+        }
+
+        // Search from hint; wrap to 0 if needed.
+        let pfn = self.find_free_from(self.next_hint).or_else(|| {
+            if self.next_hint > 0 {
+                self.find_free_from(0)
+            } else {
+                None
+            }
+        })?;
+
+        // Mark the frame allocated (clear bit).
+        let word = pfn / 64;
+        let bit = pfn % 64;
+        self.bitmap[word] &= !(1u64 << bit);
+        self.free_frames -= 1;
+        self.next_hint = word;
+
+        Some(PhysFrame::from_pfn(pfn as u64))
+    }
+
+    /// Returns a physical frame to the free pool.
+    ///
+    /// # Panics (debug builds only)
+    ///
+    /// Panics if:
+    /// - The frame's PFN is outside the allocator's addressable range.
+    /// - The frame's bit is already set (double-free detection).
+    pub fn deallocate(&mut self, frame: PhysFrame) {
+        let pfn = frame.pfn() as usize;
+        let word = pfn / 64;
+        let bit = pfn % 64;
+        debug_assert!(
+            word < WORDS,
+            "deallocate: PhysFrame pfn={} is outside allocator range (max {})",
+            pfn,
+            WORDS * 64
+        );
+        debug_assert!(
+            self.bitmap[word] & (1u64 << bit) == 0,
+            "deallocate: double-free detected for PhysFrame pfn={}",
+            pfn
+        );
+        self.bitmap[word] |= 1u64 << bit;
+        self.free_frames += 1;
+        // Allow the next allocation to reuse this frame quickly.
+        if word < self.next_hint {
+            self.next_hint = word;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Statistics
+    // -----------------------------------------------------------------------
+
+    /// Returns the number of frames currently available for allocation.
+    #[inline]
+    pub fn free_frames(&self) -> usize {
+        self.free_frames
+    }
+
+    /// Returns the total number of frames this allocator can address
+    /// (`WORDS * 64`), regardless of how many are free or usable.
+    #[inline]
+    pub fn total_frames(&self) -> usize {
+        self.total_frames
+    }
+
+    /// Returns the number of allocated frames (`total - free`).
+    #[inline]
+    pub fn allocated_frames(&self) -> usize {
+        self.total_frames.saturating_sub(self.free_frames)
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    /// Sets all frames in `[start_pfn, end_pfn)` as free (bit = 1).
+    /// Frames beyond `WORDS * 64` are silently ignored.
+    fn set_range_free(&mut self, start_pfn: usize, end_pfn: usize) {
+        for pfn in start_pfn..end_pfn {
+            let word = pfn / 64;
+            let bit = pfn % 64;
+            if word < WORDS {
+                self.bitmap[word] |= 1u64 << bit;
+            }
+        }
+    }
+
+    /// Returns the PFN of the first free frame at or after `start_word`.
+    fn find_free_from(&self, start_word: usize) -> Option<usize> {
+        for (offset, &word) in self.bitmap[start_word..].iter().enumerate() {
+            if word != 0 {
+                // `trailing_zeros` gives the position of the lowest set bit.
+                let bit = word.trailing_zeros() as usize;
+                return Some((start_word + offset) * 64 + bit);
+            }
+        }
+        None
+    }
+
+    /// Counts free frames by scanning the full bitmap (O(WORDS)).
+    /// Used once at init to establish the initial `free_frames` count.
+    fn count_free_in_bitmap(&self) -> usize {
+        self.bitmap.iter().map(|w| w.count_ones() as usize).sum()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 //
 // Even though this crate is #![no_std], cargo test links std for the test
@@ -1055,5 +1408,300 @@ mod tests {
     fn kernel_framebuffer_size() {
         // 8 (base) + 8 (size) + 4 (width) + 4 (height) + 4 (stride) + 4 (pixel_format) = 32
         assert_eq!(core::mem::size_of::<KernelFramebuffer>(), 32);
+    }
+
+    // -----------------------------------------------------------------------
+    // PhysFrame
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn phys_frame_from_aligned_addr() {
+        let frame = PhysFrame::from_addr(0x1000).expect("0x1000 is page-aligned");
+        assert_eq!(frame.pfn(), 1);
+        assert_eq!(frame.start_address(), 0x1000);
+        assert_eq!(frame.end_address(), 0x2000);
+    }
+
+    #[test]
+    fn phys_frame_from_zero_addr() {
+        let frame = PhysFrame::from_addr(0).expect("0 is page-aligned");
+        assert_eq!(frame.pfn(), 0);
+        assert_eq!(frame.start_address(), 0);
+    }
+
+    #[test]
+    fn phys_frame_from_unaligned_addr_returns_none() {
+        assert!(PhysFrame::from_addr(0x1001).is_none());
+        assert!(PhysFrame::from_addr(1).is_none());
+        assert!(PhysFrame::from_addr(4095).is_none());
+    }
+
+    #[test]
+    fn phys_frame_ordering() {
+        let a = PhysFrame::from_addr(0x1000).unwrap();
+        let b = PhysFrame::from_addr(0x2000).unwrap();
+        assert!(a < b);
+    }
+
+    // -----------------------------------------------------------------------
+    // BitmapFrameAllocator — construction and initial state
+    // -----------------------------------------------------------------------
+
+    /// Small bitmap (32 words = 2048 frames = 8 MiB) used in tests.
+    type TestAlloc = BitmapFrameAllocator<32>;
+
+    fn make_allocator_with_map(descs: &[(u32, u64, u64)]) -> (TestAlloc, MemoryMap) {
+        let raw_descs: std::vec::Vec<KernelMemoryDescriptor> = descs
+            .iter()
+            .map(|(ty, base, pages)| make_desc(*ty, *base, *pages))
+            .collect();
+        let raw_map = make_map(&raw_descs);
+        let parsed = MemoryMap::parse(&raw_map).unwrap();
+        let mut alloc = TestAlloc::new();
+        alloc.init_from_memory_map(&parsed);
+        (alloc, parsed)
+    }
+
+    #[test]
+    fn new_allocator_has_zero_free_frames() {
+        let alloc = TestAlloc::new();
+        assert_eq!(alloc.free_frames(), 0);
+        assert_eq!(alloc.total_frames(), 0);
+        assert_eq!(alloc.allocated_frames(), 0);
+    }
+
+    #[test]
+    fn init_sets_total_frames_to_words_times_64() {
+        let (alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 10)]);
+        assert_eq!(alloc.total_frames(), 32 * 64);
+    }
+
+    #[test]
+    fn init_marks_conventional_frames_free() {
+        // 10 conventional pages at 0x1000 → 10 free frames.
+        let (alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 10)]);
+        assert_eq!(alloc.free_frames(), 10);
+    }
+
+    #[test]
+    fn init_does_not_free_reclaimable_frames() {
+        // BootloaderReclaimable — not immediately available in Phase 1.
+        let (alloc, _) = make_allocator_with_map(&[(memory_type::BOOT_SERVICES_DATA, 0x1000, 10)]);
+        assert_eq!(alloc.free_frames(), 0);
+    }
+
+    #[test]
+    fn init_does_not_free_reserved_frames() {
+        let (alloc, _) = make_allocator_with_map(&[
+            (memory_type::RESERVED, 0x1000, 5),
+            (memory_type::MMIO, 0x10_0000, 8),
+        ]);
+        assert_eq!(alloc.free_frames(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // BitmapFrameAllocator — allocation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn allocate_returns_some_when_frames_available() {
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        assert!(alloc.allocate().is_some());
+    }
+
+    #[test]
+    fn allocate_returns_page_aligned_address() {
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        let frame = alloc.allocate().unwrap();
+        assert_eq!(
+            frame.start_address() % PAGE_SIZE,
+            0,
+            "start_address must be page-aligned"
+        );
+    }
+
+    #[test]
+    fn allocate_decrements_free_count() {
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        let before = alloc.free_frames();
+        alloc.allocate().unwrap();
+        assert_eq!(alloc.free_frames(), before - 1);
+    }
+
+    #[test]
+    fn allocate_returns_distinct_frames() {
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        let f1 = alloc.allocate().unwrap();
+        let f2 = alloc.allocate().unwrap();
+        assert_ne!(
+            f1, f2,
+            "consecutive allocations must return different frames"
+        );
+    }
+
+    #[test]
+    fn allocate_exhausted_returns_none() {
+        let (mut alloc, _) = make_allocator_with_map(&[
+            (memory_type::CONVENTIONAL, 0x1000, 3), // exactly 3 frames
+        ]);
+        alloc.allocate().unwrap();
+        alloc.allocate().unwrap();
+        alloc.allocate().unwrap();
+        assert_eq!(alloc.free_frames(), 0);
+        assert!(
+            alloc.allocate().is_none(),
+            "must return None when no frames remain"
+        );
+    }
+
+    #[test]
+    fn allocate_frame_is_within_usable_region() {
+        // 4 pages at 0x2000: PFNs 2, 3, 4, 5.
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x2000, 4)]);
+        for _ in 0..4 {
+            let frame = alloc.allocate().unwrap();
+            let addr = frame.start_address();
+            assert!(
+                addr >= 0x2000 && addr < 0x6000,
+                "frame address {:#x} outside usable region [0x2000, 0x6000)",
+                addr
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // BitmapFrameAllocator — deallocation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn deallocate_increments_free_count() {
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        let frame = alloc.allocate().unwrap();
+        let before = alloc.free_frames();
+        alloc.deallocate(frame);
+        assert_eq!(alloc.free_frames(), before + 1);
+    }
+
+    #[test]
+    fn deallocate_allows_reallocation_of_same_frame() {
+        let (mut alloc, _) = make_allocator_with_map(&[
+            (memory_type::CONVENTIONAL, 0x1000, 1), // only one frame
+        ]);
+        let frame1 = alloc.allocate().unwrap();
+        assert!(alloc.allocate().is_none()); // exhausted
+
+        alloc.deallocate(frame1);
+        let frame2 = alloc.allocate();
+        assert!(
+            frame2.is_some(),
+            "frame must be re-allocatable after deallocation"
+        );
+    }
+
+    #[test]
+    fn deallocate_and_reallocate_full_cycle() {
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        let frames: std::vec::Vec<_> = (0..4).map(|_| alloc.allocate().unwrap()).collect();
+        assert_eq!(alloc.free_frames(), 0);
+        for f in frames {
+            alloc.deallocate(f);
+        }
+        assert_eq!(alloc.free_frames(), 4);
+    }
+
+    // -----------------------------------------------------------------------
+    // BitmapFrameAllocator — mark_reserved
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mark_reserved_reduces_free_count() {
+        let (mut alloc, _) = make_allocator_with_map(&[
+            (memory_type::CONVENTIONAL, 0x1000, 4), // 4 free frames
+        ]);
+        let before = alloc.free_frames();
+        // Reserve 2 pages starting at 0x2000 (PFNs 2 and 3).
+        alloc.mark_reserved(0x2000, 2 * PAGE_SIZE);
+        assert_eq!(alloc.free_frames(), before - 2);
+    }
+
+    #[test]
+    fn mark_reserved_prevents_allocation_in_range() {
+        // 4 pages at PFNs 1..=4 (addresses 0x1000..0x5000).
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        // Reserve PFNs 2 and 3 (0x2000 and 0x3000).
+        alloc.mark_reserved(0x2000, 2 * PAGE_SIZE);
+
+        let mut returned_addrs = std::vec::Vec::new();
+        while let Some(frame) = alloc.allocate() {
+            returned_addrs.push(frame.start_address());
+        }
+        assert!(
+            !returned_addrs.contains(&0x2000),
+            "0x2000 was reserved but returned by allocator"
+        );
+        assert!(
+            !returned_addrs.contains(&0x3000),
+            "0x3000 was reserved but returned by allocator"
+        );
+    }
+
+    #[test]
+    fn mark_reserved_idempotent_on_already_reserved_frames() {
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        let before = alloc.free_frames();
+        // Reserve a region twice — count should only drop once.
+        alloc.mark_reserved(0x1000, PAGE_SIZE);
+        let after_first = alloc.free_frames();
+        alloc.mark_reserved(0x1000, PAGE_SIZE);
+        assert_eq!(
+            alloc.free_frames(),
+            after_first,
+            "marking an already-reserved frame must not double-decrement free_frames"
+        );
+        assert_eq!(after_first, before - 1);
+    }
+
+    #[test]
+    fn mark_reserved_zero_size_is_noop() {
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        let before = alloc.free_frames();
+        alloc.mark_reserved(0x1000, 0);
+        assert_eq!(alloc.free_frames(), before);
+    }
+
+    // -----------------------------------------------------------------------
+    // BitmapFrameAllocator — multiple regions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn init_with_multiple_conventional_regions() {
+        let (alloc, _) = make_allocator_with_map(&[
+            (memory_type::CONVENTIONAL, 0x1000, 3),
+            (memory_type::RESERVED, 0x10_0000, 10), // skipped
+            (memory_type::CONVENTIONAL, 0x20_0000, 5),
+        ]);
+        assert_eq!(alloc.free_frames(), 8); // 3 + 5
+    }
+
+    #[test]
+    fn allocated_frames_stat_is_consistent() {
+        let (mut alloc, _) = make_allocator_with_map(&[(memory_type::CONVENTIONAL, 0x1000, 4)]);
+        alloc.allocate().unwrap();
+        alloc.allocate().unwrap();
+        assert_eq!(
+            alloc.free_frames() + alloc.allocated_frames(),
+            alloc.total_frames()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // BitmapFrameAllocator — KERNEL_BITMAP_WORDS constant
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn kernel_bitmap_words_covers_64_gib() {
+        // KERNEL_BITMAP_WORDS * 64 frames * 4 KiB/frame == 64 GiB
+        let max_bytes: u64 = KERNEL_BITMAP_WORDS as u64 * 64 * PAGE_SIZE;
+        assert_eq!(max_bytes, 64 * 1024 * 1024 * 1024);
     }
 }


### PR DESCRIPTION
## Summary

Implements Phase 1.3.2: physical memory frame allocator. Closes #13.

- Adds `PhysFrame` (frame handle type) and `BitmapFrameAllocator<const WORDS: usize>` to `ferrous-boot-info`, keeping the core allocator logic host-testable
- Adds `kernel::memory::frame_allocator` module wrapping a 2 MiB static bitmap instance (lives in BSS, zero binary bloat) with `init`, `allocate`, `deallocate`, `mark_reserved`, and stat query functions
- Wires the allocator into `boot/src/main.rs` Step 6: parses the `MemoryMap`, initialises the allocator, prints frame stats, and runs an inline smoke test (allocate 3 frames, verify distinct + 4 KiB aligned, deallocate, verify free count recovers)

### Design decisions

| Decision | Rationale |
|----------|-----------|
| Bitmap allocator | Architecture doc specifies this for Phase 1: simple, predictable, O(n) alloc with hint |
| Bit 1 = free, bit 0 = reserved | BSS zero-init starts all frames reserved — safe default before `init` runs |
| `const fn new()` returning all-zeros | Static lands in BSS, not data segment; 2 MiB bitmap = zero binary overhead |
| Core logic in `ferrous-boot-info` | Follows 1.3.1 pattern: host-testable without `x86_64-unknown-none` toolchain |
| `PhysFrame` is `Copy` | No `Drop` in Phase 1 (would create circular dep `boot-info` -> `kernel`); explicit dealloc API; Phase 2 adds RAII |
| Phase 1 threading model | Single-core, interrupts disabled during alloc; `unsafe` API; Phase 2 adds spinlock |

### QEMU serial output (Step 6)

```
[OK] Frame allocator initialised
[INFO] Physical frames: 52311 free / 16777216 addressable (209244 KiB usable)
[TEST] Allocating 3 frames...
[OK]   frame[0] = 0x0
[OK]   frame[1] = 0x1000
[OK]   frame[2] = 0x2000
[OK]   All frames are distinct
[OK]   All frames are 4 KiB aligned
[OK]   Deallocation restored free count (+3)
```

## Test plan

- [x] `cargo test -p ferrous-boot-info` -- 70 tests pass (25 new allocator tests added)
- [x] `scripts/verify-boot.sh` passes end-to-end in QEMU
- [x] Allocator smoke test (3 alloc + 3 dealloc) passes in QEMU
- [x] `cargo +nightly build -p ferrous-kernel --target x86_64-unknown-none` compiles without errors