### PR TITLE
feat(memory): virtual memory setup — page tables and CR3 switch (Phase 1.3.3)

### DIFF
--- a/boot/src/main.rs
+++ b/boot/src/main.rs
@@ -118,6 +118,114 @@ static mut KERNEL_BOOT_INFO: KernelBootInfo = KernelBootInfo::new();
 static mut FRAME_ALLOC: BitmapFrameAllocator<KERNEL_BITMAP_WORDS> = BitmapFrameAllocator::new();
 
 // ---------------------------------------------------------------------------
+// Page tables (Phase 1.3.3)
+//
+// Three raw 4 KiB page tables in BSS.  Populated by `setup_page_tables()`
+// during Step 7 of `kernel_main` (after the frame allocator is live).
+//
+// Layout after init:
+//   PML4[0]   → PDPT   (identity: VA [0, 1 GiB) = PA [0, 1 GiB))
+//   PML4[256] → PDPT   (higher-half alias: VA 0xFFFF_8000_... = PA 0x0...)
+//   PDPT[0]   → PD
+//   PD[0..511]→ 512 × 2 MiB huge pages  (PA i×2MiB, Present+Writable+PS)
+// ---------------------------------------------------------------------------
+
+/// Page present (P, bit 0).
+const PT_PRESENT: u64 = 1 << 0;
+/// Page writable (R/W, bit 1).
+const PT_WRITABLE: u64 = 1 << 1;
+/// Huge page / page size (PS, bit 7).  In a PD entry: maps a 2 MiB page.
+const PT_HUGE: u64 = 1 << 7;
+/// Mask for the physical address stored in a page table entry (bits [51:12]).
+const PT_PHYS_MASK: u64 = 0x000F_FFFF_FFFF_F000;
+
+/// A raw 4 KiB page table: 512 × 8-byte entries, 4 KiB-aligned.
+///
+/// The alignment guarantee means `addr_of!(PT_PML4) as u64` has its low 12
+/// bits clear — safe to write directly to CR3.
+#[repr(C, align(4096))]
+struct RawPageTable([u64; 512]);
+
+/// PML4 — the root of the kernel's page table hierarchy.
+///
+/// SAFETY: mutated exactly once in `setup_page_tables()` before CR3 is
+/// loaded.  Single-threaded, interrupts disabled throughout.
+#[allow(static_mut_refs)]
+static mut PT_PML4: RawPageTable = RawPageTable([0u64; 512]);
+
+/// PDPT — shared by the identity window (PML4[0]) and the higher-half alias
+/// (PML4[256]).
+#[allow(static_mut_refs)]
+static mut PT_PDPT: RawPageTable = RawPageTable([0u64; 512]);
+
+/// PD — 512 × 2 MiB huge-page entries covering [0, 1 GiB).
+#[allow(static_mut_refs)]
+static mut PT_PD: RawPageTable = RawPageTable([0u64; 512]);
+
+/// Build the kernel page tables and return the physical address of the PML4.
+///
+/// Under UEFI identity mapping every static lives at `VA == PA`, so the
+/// pointer value is both the virtual and the physical address.  After `CR3`
+/// is loaded with the returned value:
+///
+/// - `[0, 1 GiB)` is identity-mapped with 2 MiB huge pages (execution
+///   continues at the same virtual addresses — no jump required).
+/// - `[0xFFFF_8000_0000_0000, 0xFFFF_8000_4000_0000)` aliases the same
+///   physical range (higher-half window for Phase 2).
+///
+/// # Safety
+///
+/// - Must be called **exactly once**.
+/// - Must be called **single-threaded** with interrupts disabled.
+/// - UEFI identity mapping (`VA == PA`) must still be in effect.
+unsafe fn setup_page_tables() -> u64 {
+    // Obtain raw mutable pointers to the three table arrays.
+    // Using `addr_of_mut!` avoids creating Rust references to `static mut`
+    // (which would require `#[allow(static_mut_refs)]` and risks aliasing).
+    //
+    // Each pointer is to a `RawPageTable` which contains `[u64; 512]`, so
+    // casting to `*mut u64` is safe — `repr(C)` guarantees the array starts
+    // at offset 0.
+    let pml4 = core::ptr::addr_of_mut!(PT_PML4) as *mut u64;
+    let pdpt = core::ptr::addr_of_mut!(PT_PDPT) as *mut u64;
+    let pd = core::ptr::addr_of_mut!(PT_PD) as *mut u64;
+
+    // Zero all three tables.  BSS is already zeroed by the UEFI firmware,
+    // but we zero explicitly so the invariant is independent of the loader.
+    for i in 0..512usize {
+        pml4.add(i).write(0u64);
+        pdpt.add(i).write(0u64);
+        pd.add(i).write(0u64);
+    }
+
+    // PD: 512 × 2 MiB huge pages covering [0, 1 GiB).
+    //   Entry i maps physical address i × 2 MiB.
+    //   Flags: Present | Writable | HugePage (PS=1).
+    for i in 0..512usize {
+        let phys = (i as u64) * (2 * 1024 * 1024); // i × 2 MiB
+        pd.add(i)
+            .write((phys & PT_PHYS_MASK) | PT_PRESENT | PT_WRITABLE | PT_HUGE);
+    }
+
+    // PDPT[0] → PD.
+    let pd_phys = core::ptr::addr_of!(PT_PD) as u64; // VA == PA (UEFI)
+    pdpt.write((pd_phys & PT_PHYS_MASK) | PT_PRESENT | PT_WRITABLE);
+
+    // PML4[0] → PDPT  (identity window: VA 0 maps to PA 0).
+    let pdpt_phys = core::ptr::addr_of!(PT_PDPT) as u64;
+    pml4.write((pdpt_phys & PT_PHYS_MASK) | PT_PRESENT | PT_WRITABLE);
+
+    // PML4[256] → same PDPT  (higher-half alias: 0xFFFF_8000_0000_0000).
+    //
+    // Bits [47:39] of 0xFFFF_8000_0000_0000 = 0x100 = 256.
+    pml4.add(256)
+        .write((pdpt_phys & PT_PHYS_MASK) | PT_PRESENT | PT_WRITABLE);
+
+    // Return the physical address of PML4 — this goes directly into CR3.
+    core::ptr::addr_of!(PT_PML4) as u64
+}
+
+// ---------------------------------------------------------------------------
 // Panic handler
 // ---------------------------------------------------------------------------
 
@@ -626,6 +734,118 @@ fn kernel_main(boot_info: &KernelBootInfo) -> ! {
         serial_write_str(" @ 0x");
         serial_write_usize_hex(boot_info.framebuffer.base as usize);
         serial_write_str("\r\n");
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 7: Build kernel page tables and switch CR3 (Phase 1.3.3).
+    //
+    // Replaces UEFI's firmware page tables with Ferrous's own minimal set:
+    //
+    //   PML4[0]   → PDPT → PD → 512 × 2 MiB huge pages  (identity [0, 1 GiB))
+    //   PML4[256] → PDPT                                  (higher-half alias)
+    //
+    // Because we identity-map [0, 1 GiB), the `MOV CR3` instruction and all
+    // subsequent loads/stores continue at the same virtual addresses — no
+    // far jump to a different VA is needed.
+    //
+    // After the switch we read CR3 back to confirm the value was accepted and
+    // then dereference a pointer through the higher-half window to prove that
+    // aliased mapping is live.
+    //
+    // SAFETY:
+    // - `setup_page_tables()` is called exactly once, single-threaded.
+    // - Interrupts are disabled (cli executed in efi_main).
+    // - UEFI identity mapping is still in effect (VA == PA for all statics).
+    // - Identity mapping covers [0, 1 GiB) ⊇ {current RIP, RSP, statics},
+    //   so execution is unaffected by the CR3 switch.
+    serial_write_str("\r\n[...] Setting up kernel page tables\r\n");
+
+    let pml4_phys = unsafe { setup_page_tables() };
+
+    serial_write_str("[INFO] PML4 physical address: 0x");
+    serial_write_usize_hex(pml4_phys as usize);
+    serial_write_str("\r\n");
+
+    // Load CR3 — installs our page tables and flushes the TLB.
+    //
+    // SAFETY: `pml4_phys` is the page-aligned physical address of a fully
+    // populated PML4.  The low 12 bits are zero (PWT=0, PCD=0 — write-back,
+    // cacheable).  Interrupts are disabled so no handler can fire with a
+    // partially-loaded CR3.
+    unsafe {
+        core::arch::asm!(
+            "mov cr3, {pml4}",
+            pml4 = in(reg) pml4_phys,
+            options(nostack),
+        );
+    }
+
+    serial_write_str("[OK] CR3 loaded — kernel page tables active\r\n");
+
+    // Read CR3 back and verify the CPU accepted our value.
+    //
+    // Reading CR3 returns the base address plus the PWT/PCD flag bits.  Since
+    // we wrote a page-aligned address with no flags, the readback must equal
+    // `pml4_phys` exactly.
+    let cr3_readback: u64;
+    unsafe {
+        core::arch::asm!(
+            "mov {cr3}, cr3",
+            cr3 = out(reg) cr3_readback,
+            options(nomem, nostack),
+        );
+    }
+
+    if cr3_readback == pml4_phys {
+        serial_write_str("[OK] CR3 readback verified (0x");
+        serial_write_usize_hex(cr3_readback as usize);
+        serial_write_str(")\r\n");
+    } else {
+        serial_write_str("[FAIL] CR3 readback mismatch! wrote 0x");
+        serial_write_usize_hex(pml4_phys as usize);
+        serial_write_str(" read 0x");
+        serial_write_usize_hex(cr3_readback as usize);
+        serial_write_str("\r\n");
+    }
+
+    // Print the mapped ranges.
+    serial_write_str(
+        "[INFO] Identity map: [0x0000000000000000, 0x0000000040000000)  1 GiB  2 MiB pages\r\n",
+    );
+    serial_write_str(
+        "[INFO] Higher-half:  [0xffff800000000000, 0xffff800040000000) → same physical\r\n",
+    );
+
+    // Probe the higher-half alias: read a u64 through the higher-half window
+    // and compare it to the same u64 read through the identity window.
+    //
+    // We use the first entry of PT_PML4 as the test target because:
+    //   - Its identity-map VA equals its PA (UEFI; unchanged after our CR3
+    //     load because identity mapping is preserved).
+    //   - Its higher-half VA = identity VA + 0xFFFF_8000_0000_0000.
+    //   - It was written by setup_page_tables(), so it is non-zero.
+    //
+    // SAFETY:
+    // - Both VAs are now mapped (identity + higher-half) after the CR3 switch.
+    // - We only read (no write) so the test cannot corrupt state.
+    let identity_va = core::ptr::addr_of!(PT_PML4) as u64;
+    let higher_half_va = identity_va.wrapping_add(0xFFFF_8000_0000_0000u64);
+
+    let val_identity: u64 = unsafe { (identity_va as *const u64).read_volatile() };
+    let val_higher: u64 = unsafe { (higher_half_va as *const u64).read_volatile() };
+
+    if val_identity == val_higher && val_identity != 0 {
+        serial_write_str("[OK] Higher-half alias verified (PML4[0] = 0x");
+        serial_write_usize_hex(val_identity as usize);
+        serial_write_str(" via both windows)\r\n");
+    } else if val_identity != val_higher {
+        serial_write_str("[FAIL] Higher-half alias mismatch: identity=0x");
+        serial_write_usize_hex(val_identity as usize);
+        serial_write_str(" higher=0x");
+        serial_write_usize_hex(val_higher as usize);
+        serial_write_str("\r\n");
+    } else {
+        serial_write_str("[WARN] Higher-half alias read zero — PML4[0] unexpectedly empty\r\n");
     }
 
     serial_write_str(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Ferrous Kernel - System Architecture
 
-**Version:** 0.1  
-**Date:** 2026-01-04  
-**Status:** Design Phase (Phase 0)
+**Version:** 0.2  
+**Date:** 2026-05-02  
+**Status:** Phase 1 — Proof of Life (In Progress)
 
 ---
 
@@ -541,15 +541,22 @@ Ferrous provides a capability-based system call interface:
 
 ## Design Evolution
 
-### Phase 0 (Current): Foundation & Design
+### Phase 0: Foundation & Design — COMPLETE (Q1 2026)
 - Architecture document (this document)
 - Detailed subsystem designs
 - ADR template and initial ADRs
 
-### Phase 1: Proof of Life
+### Phase 1: Proof of Life — IN PROGRESS (Q2-Q3 2026)
 - Basic boot and memory management
 - No user-space yet
 - Foundation for all subsystems
+
+**Completed milestones:**
+- 1.1 Bare Metal Boot — UEFI entry, serial output, GDT, IDT, exception handlers
+- 1.2 Runtime Setup — kernel stack, GDT, IDT, basic exception handling
+- 1.3.1 Parse UEFI Memory Map — `MemoryMap` in `ferrous-boot-info`, global `init`/`get`
+- 1.3.2 Physical Frame Allocator — `BitmapFrameAllocator<262144>`, 52,311 free frames on QEMU
+- 1.3.3 Virtual Memory Setup — `VirtualAddress`, `PhysicalAddress`, `PageTable`, `KernelPageTable`; CR3 loaded, higher-half alias at `0xFFFF_8000_0000_0000` confirmed live
 
 ### Phase 2: Core Kernel
 - Scheduler, IPC, capabilities
@@ -622,8 +629,8 @@ This architecture prioritizes **correctness and safety** over features, enabling
 ---
 
 **Next Steps**: 
-1. Create detailed design documents for each subsystem (Phase 0)
-2. Begin implementation of boot and memory management (Phase 1)
+1. Complete Phase 1.3 memory management (1.3.4 page management, 1.3.5 heap allocator)
+2. Complete Phase 1.4 core infrastructure (logging, panic handler, debug macros)
 3. Iterate on architecture based on implementation experience
 
 ---

--- a/docs/BOOT_ARCHITECTURE.md
+++ b/docs/BOOT_ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Ferrous Kernel - Boot Process Overview
 
-**Version:** 0.1  
-**Date:** 2026-01-04  
-**Status:** Design Phase (Phase 0)
+**Version:** 0.2  
+**Date:** 2026-05-02  
+**Status:** Phase 1 — Proof of Life (In Progress)
 
 ---
 
@@ -560,20 +560,30 @@ pub enum BootError {
 
 ### Phase 1: Basic Boot
 
-**Deliverables**:
-- UEFI entry point and handoff
-- Basic CPU setup (GDT, IDT)
-- Memory map parsing
-- Physical memory allocator
-- Virtual memory setup (identity mapping)
-- Kernel heap setup
-- Basic serial output
+**Deliverables and Status**:
+
+| Deliverable | Status | Notes |
+|-------------|--------|-------|
+| UEFI entry point and handoff | ✅ Complete (PR #56) | `kernel_entry` via RETFQ stack switch |
+| Basic serial output (COM1 UART) | ✅ Complete (PR #58) | 115200 8N1, `serial_write_str` helpers |
+| Kernel stack setup | ✅ Complete (PR #60) | 64 KiB + 4 KiB soft guard; `KernelStack<N>` |
+| GDT (null / kernel-code / kernel-data) | ✅ Complete (PR #61) | Loaded via `LGDT` + far-return CS reload |
+| IDT (32 exception stubs + IRQ) | ✅ Complete (PR #62) | `isr_stub` / `isr_stub_ec` asm macros |
+| Basic exception handlers | ✅ Complete (PR #63) | Prints vector, error code, RIP, CR2 (#PF) |
+| Memory map parsing | ✅ Complete (PR #64) | `MemoryMap` in `ferrous-boot-info`; global `init`/`get` |
+| Physical memory allocator | ✅ Complete (PR #87) | `BitmapFrameAllocator<262144>`; 52,311 free frames on QEMU |
+| Virtual memory setup | ✅ Complete (PR #88) | `KernelPageTable`; 2 MiB huge pages; CR3 loaded; higher-half alias confirmed |
+| Kernel heap setup | ⬜ Pending (1.3.5) | `GlobalAlloc` impl; `Box`/`Vec` available |
+| Logging framework | ⬜ Pending (1.4.1) | Structured serial logging |
+| Panic handler with stack traces | ⬜ Pending (1.4.2) | Source location + register dump |
 
 **Success Criteria**:
-- Kernel boots on QEMU x86_64
-- Can print "Hello from Ferrous!" to serial console
-- Paging is enabled
-- Kernel heap allocation works
+- [x] Kernel boots on QEMU x86_64
+- [x] Can print "Hello from Ferrous!" to serial console
+- [x] Page fault handler catches and reports violations
+- [x] Kernel owns its page tables (CR3 loaded, higher-half alias live)
+- [ ] Kernel heap allocation works (`Box`, `Vec` available)
+- [ ] Clean panic messages with source locations
 
 ### Phase 2: Full Boot Sequence
 

--- a/docs/MEMORY_ARCHITECTURE.md
+++ b/docs/MEMORY_ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Ferrous Kernel - Memory Management Architecture
 
-**Version:** 0.3
-**Date:** 2026-05-01
-**Status:** Phase 1 In Progress (1.3.1 and 1.3.2 complete, 1.3.3-1.3.5 pending)
+**Version:** 0.4
+**Date:** 2026-05-02
+**Status:** Phase 1 In Progress (1.3.1, 1.3.2, and 1.3.3 complete, 1.3.4-1.3.5 pending)
 
 ---
 
@@ -584,15 +584,16 @@ pub enum MemoryError {
    - Phase 1 threading: single-core, interrupts disabled; `unsafe` API; Phase 2 adds spinlock
    - QEMU boot output confirms 52,311 free frames / 204 MiB usable; 3-frame smoke test passes
 
-3. **Set Up Kernel Page Tables** -- Phase 1.3.3/1.3.4 (pending)
-   - Identity map physical memory (temporary)
-   - Map kernel code/data sections
-   - Enable paging (CR0.PG = 1)
+3. **Set Up Kernel Page Tables** -- COMPLETE (Phase 1.3.3, PR #88)
+   - `kernel::memory::paging` added: `VirtualAddress` (canonical-form validated), `PhysicalAddress`, `PageTableEntry` + `flags` constants, `PageTable` ([PageTableEntry; 512], 4 KiB-aligned), `KernelPageTable` (Phase 1 mapper — PML4 + PDPT + PD inline)
+   - Phase 1 uses **2 MiB huge pages** (PS=1 in PD entries): `PML4[0]→PDPT[0]→PD[0..511]` covers [0, 1 GiB) identity; `PML4[256]→PDPT` creates higher-half alias at `0xFFFF_8000_0000_0000`
+   - Boot Step 7 (`setup_page_tables`) populates three raw 4 KiB BSS statics via raw pointer writes (`addr_of_mut!`), loads PML4 physical address into CR3 (`MOV CR3`)
+   - CR3 readback verified; higher-half alias confirmed via `read_volatile` through `0xFFFF_8000_...` VA; QEMU boot verification passes
+   - Note: identity map is permanent in Phase 1 (no linker script for kernel VMA yet); Phase 1.3.4 adds fine-grained 4 KiB page mappings
 
-4. **Switch to Higher-Half Kernel** -- Phase 1.3.3 (pending)
-   - Remap kernel to high virtual addresses (0xFFFF_8000_0000_0000+)
-   - Remove low-memory identity mapping
-   - Update all kernel pointers
+4. **Switch to Higher-Half Kernel** -- Deferred to Phase 2
+   - Phase 1 establishes the higher-half alias window but the kernel continues running at identity-mapped VAs (same binary, no linker-script VMA offset)
+   - Full higher-half switch (kernel loaded at `0xFFFF_8000_0000_0000`, low identity map removed) happens when the kernel becomes a separate ELF binary in Phase 2
 
 5. **Initialize Kernel Heap** -- Phase 1.3.5 (pending)
    - Allocate initial heap frames from physical allocator
@@ -611,16 +612,19 @@ pub enum MemoryError {
 |------|--------|-------|
 | UEFI memory map parsing | Complete (PR #64) | `MemoryMap`, `MemoryRegionKind`, `MemoryStats` in `ferrous-boot-info`; global `init`/`get` in `kernel::memory` |
 | Physical frame allocator (bitmap) | Complete (PR #87) | `BitmapFrameAllocator<262144>` in `ferrous-boot-info`; 2 MiB BSS bitmap; 52,311 free frames on QEMU |
-| Basic page table management (4 KB pages) | Pending (1.3.3/1.3.4) | x86-64 4-level PT; identity map then higher-half switch |
+| Basic page table management (2 MiB huge pages) | Complete (PR #88) | `VirtualAddress`, `PhysicalAddress`, `PageTableEntry`, `PageTable`, `KernelPageTable`; identity + higher-half alias confirmed on QEMU |
+| Fine-grained 4 KiB page mapping | Pending (1.3.4) | Walk existing tables, allocate PT frames, map/unmap individual pages |
 | Kernel heap allocator (linked list) | Pending (1.3.5) | Implements `GlobalAlloc`; migrate to buddy in Phase 2 |
-| Higher-half kernel address space | Pending (1.3.3) | Kernel at 0xFFFF_8000_0000_0000+ |
+| Higher-half kernel binary (Phase 2) | Pending | Full ELF relocation to `0xFFFF_8000_0000_0000`; remove identity map |
 
 **Success Criteria**:
 - [x] UEFI memory map parsed, classified, and accessible to all kernel subsystems
 - [x] Kernel can allocate and free physical frames
-- [ ] Kernel can create page tables and map pages
+- [x] Kernel owns its page tables (replaced UEFI firmware tables with Ferrous tables at boot)
+- [x] Higher-half window established at `0xFFFF_8000_0000_0000`
+- [ ] Kernel can map/unmap individual 4 KiB pages
 - [ ] Kernel heap allocation works (`Box`, `Vec` available)
-- [ ] Boot completes with paging enabled
+- [ ] Kernel binary loaded at higher-half VMA
 
 ### Phase 2: Process Memory
 

--- a/docs/QEMU_TESTING.md
+++ b/docs/QEMU_TESTING.md
@@ -1,6 +1,6 @@
 # QEMU Testing Guide
 
-**Last Updated:** 2026-03-07
+**Last Updated:** 2026-05-02
 **Applies to:** Phase 1 (Proof of Life)
 
 ---
@@ -102,9 +102,9 @@ Adjust the OVMF path for your system:
 
 ---
 
-## Expected Output — Phase 1.1 (Bare Metal Boot)
+## Expected Output — Phase 1 Current (through 1.3.3)
 
-A successful Phase 1.1 boot produces the following on the serial console. This output is the authoritative reference for the `verify-boot.sh` script.
+A successful boot through Phase 1.3.3 produces the following on the serial console. This output is the authoritative reference for the `verify-boot.sh` script.
 
 ```
 ========================================
@@ -117,12 +117,6 @@ A successful Phase 1.1 boot produces the following on the serial console. This o
 [...] Retrieving memory map
     Found 99 memory regions
 [OK] Memory map retrieved
-
-Memory Map Summary:
--------------------
-  0x0000000000 - 0x00000a0000: Conventional (640 KB)
-  ... (entries vary by QEMU version and RAM size)
-
 [...] Looking for ACPI tables
 [OK] ACPI RSDP found at: 0xf77e014
 [...] Looking for GOP framebuffer
@@ -139,15 +133,42 @@ Memory Map Summary:
 
 === Ferrous Kernel ===
 [OK] kernel_entry: BootInfo validated
+[OK] Kernel stack active
+[INFO] Kernel stack: 0x<addr> - 0x<addr> (64 KiB, guard=4 KiB)
+[OK] GDT loaded (null / kernel-code 0x08 / kernel-data 0x10)
+[OK] IDT loaded (32 exception handlers with error codes + RIP + CR2, interrupts disabled)
 [OK] Kernel entered successfully!
 Hello from Ferrous!
 
-Memory map entries: 99
-[INFO] ACPI RSDP present
-[INFO] Framebuffer present
+[INFO] Physical memory map (99 entries):
+  [0] 0x1000 - 0xa0000  ...
+  ... (entries vary by QEMU version and RAM size)
+[INFO] RAM: 12543 MiB total | 204 MiB usable | 45 MiB reclaimable
 
-Kernel halting. Phase 1.2 (runtime setup) not yet implemented.
+[OK] Frame allocator initialised
+[INFO] Physical frames: 52306 free / 16777216 addressable (209224 KiB usable)
+[TEST] Allocating 3 frames...
+[OK]   frame[0] = 0x0
+[OK]   frame[1] = 0x1000
+[OK]   frame[2] = 0x2000
+[OK]   All frames are distinct
+[OK]   All frames are 4 KiB aligned
+[OK]   Deallocation restored free count (+3)
+[INFO] ACPI RSDP: 0xf77e014
+[INFO] Framebuffer: 1280x800 @ 0x80000000
+
+[...] Setting up kernel page tables
+[INFO] PML4 physical address: 0x<addr>
+[OK] CR3 loaded — kernel page tables active
+[OK] CR3 readback verified (0x<addr>)
+[INFO] Identity map: [0x0000000000000000, 0x0000000040000000)  1 GiB  2 MiB pages
+[INFO] Higher-half:  [0xffff800000000000, 0xffff800040000000) → same physical
+[OK] Higher-half alias verified (PML4[0] = 0x<value> via both windows)
+
+Kernel halting. Exception handlers active — any CPU exception will be caught.
 ```
+
+Addresses shown as `0x<addr>` vary per run depending on where UEFI loads the binary.
 
 ### Verification checklist
 
@@ -157,6 +178,13 @@ After running, confirm these lines appear in the output:
 - [ ] `kernel_entry: BootInfo validated`
 - [ ] `Kernel entered successfully!`
 - [ ] `Hello from Ferrous!`
+- [ ] `GDT loaded`
+- [ ] `IDT loaded`
+- [ ] `Frame allocator initialised`
+- [ ] `Deallocation restored free count (+3)`
+- [ ] `CR3 loaded — kernel page tables active`
+- [ ] `CR3 readback verified`
+- [ ] `Higher-half alias verified`
 
 The boot info magic (`0xfe220b00cafe0001`) must match exactly — it validates the `KernelBootInfo` ABI between bootloader and kernel.
 
@@ -353,18 +381,18 @@ Physical hardware testing has not been performed as of Phase 1.1. If you test on
 
 ---
 
-## Known Limitations (Phase 1.1)
+## Known Limitations (Phase 1, through 1.3.3)
 
-| Limitation | Detail |
-|------------|--------|
-| No GDT/IDT | Using UEFI's descriptor tables. Any exception triple-faults. |
-| No kernel heap | No memory allocation after handoff. |
-| Bootstrap stack only | 16 KiB, no guard page. Stack overflow is undetected. |
-| No interrupt handling | Hardware interrupts disabled (`cli` before jump). |
-| Single core | Only the boot processor is active. |
-| Halts immediately | After printing boot info, the kernel executes `hlt` forever. |
-
-These are all tracked in Phase 1.2 and 1.3 issues.
+| Limitation | Detail | Tracked |
+|------------|--------|---------|
+| No kernel heap | No `Box`/`Vec` — heap allocator not yet implemented. | Issue #20 (1.3.5) |
+| Identity map only | Kernel runs at identity-mapped VAs; full higher-half relocation pending. | Phase 2 |
+| 2 MiB page granularity | Page tables use huge pages; individual 4 KiB map/unmap not yet implemented. | Issue #19 (1.3.4) |
+| No logging framework | Serial output via raw `serial_write_str` helpers; structured logging pending. | Issue #21 (1.4.1) |
+| No panic source locations | Panic handler is a bare `hlt` loop; stack traces pending. | Issue #22 (1.4.2) |
+| Hardware interrupts disabled | `cli` executed before handoff; only CPU exceptions are caught. | Phase 2 (scheduler) |
+| Single core | Only the boot processor is active. | Phase 2+ |
+| Stack guard is soft | Guard region is zeroed BSS, not a non-present page. | Enforced once page management (1.3.4) is done |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Ferrous Kernel - Development Roadmap
 
-**Last Updated:** 2026-05-01
+**Last Updated:** 2026-05-02
 **Status:** Phase 1 — Proof of Life (In Progress)
 
 ---
@@ -95,6 +95,8 @@ Every milestone must advance these core goals:
 - `PhysFrame` and `BitmapFrameAllocator<const WORDS>` added to `ferrous-boot-info` — bitmap allocator (bit=1 free, bit=0 reserved); `const fn new()` produces all-zeros (BSS-safe); `init_from_memory_map` marks conventional regions free; O(1) amortised allocation with word-level hint; double-free detection in debug builds; 25 new host-side tests (70 total)
 - `kernel/src/memory/frame_allocator.rs` added — 2 MiB `static mut BitmapFrameAllocator<262144>` (64 GiB capacity, lives in BSS); `AtomicBool` init guard with Release/Acquire ordering; `unsafe` `init`, `allocate`, `deallocate`, `mark_reserved` API; safe stat queries `free_frames()`, `total_frames()`, `allocated_frames()`
 - `boot/src/main.rs` kernel_main Step 6 — initialises frame allocator, prints free/total frame counts and usable KiB, runs 3-frame smoke test (allocate, verify distinct + 4 KiB aligned, deallocate, verify count recovery); confirmed on QEMU (52,311 free frames / 204 MiB usable)
+- `kernel/src/memory/paging/` added — canonical page table types: `VirtualAddress` (canonical-form validated), `PhysicalAddress`, `PageTableEntry` + `flags` constants, `PageTable` ([PageTableEntry; 512], 4 KiB-aligned), `KernelPageTable` (PML4+PDPT+PD inline, Phase 1 mapper); `paging` added to `kernel::memory`
+- `boot/src/main.rs` kernel_main Step 7 — `setup_page_tables()` builds 3-level hierarchy (PML4→PDPT→PD) with 512 × 2 MiB huge pages covering [0, 1 GiB) identity + PML4[256] higher-half alias at 0xFFFF_8000_0000_0000; `MOV CR3` loads our tables; CR3 readback verified; higher-half alias probed via `read_volatile` (PML4[0]=0xde1d023 matching through both windows); QEMU boot verification passes
 
 #### 1.2 - Runtime Setup
 
@@ -111,7 +113,7 @@ Every milestone must advance these core goals:
 |------|-------|--------|
 | 1.3.1 Parse UEFI Memory Map | #10 | Complete (PR #64) |
 | 1.3.2 Physical Memory Allocator | #13 | Complete (PR #87) |
-| 1.3.3 Virtual Memory Setup | #14 | Not Started |
+| 1.3.3 Virtual Memory Setup | #14 | Complete (PR #88) |
 | 1.3.4 Page Table Management | #19 | Not Started |
 | 1.3.5 Kernel Heap Allocator | #20 | Not Started |
 

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -28,8 +28,16 @@
 //! [`ParseError`]) live in [`ferrous_boot_info`] so they can be tested on the
 //! host without targeting `x86_64-unknown-none`. They are re-exported here
 //! for ergonomic access within the kernel.
+//!
+//! # Sub-modules
+//!
+//! | Module              | Contents                                                  |
+//! |---------------------|-----------------------------------------------------------|
+//! | [`frame_allocator`] | Global physical frame allocator (bitmap-based)            |
+//! | [`paging`]          | Virtual memory — address types, page tables, mapper       |
 
 pub mod frame_allocator;
+pub mod paging;
 
 use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicBool, Ordering};

--- a/kernel/src/memory/paging/entry.rs
+++ b/kernel/src/memory/paging/entry.rs
@@ -1,0 +1,167 @@
+//! Page table entry type and flag bit constants.
+//!
+//! A single `PageTableEntry` is an 8-byte quantity used at every level of the
+//! x86-64 four-level page table hierarchy (PML4, PDPT, PD, PT).  The
+//! interpretation of some flag bits varies by level; see the Intel SDM
+//! Vol 3A §4.5 for the full specification.
+
+// ---------------------------------------------------------------------------
+// Flag constants
+// ---------------------------------------------------------------------------
+
+/// Page table entry flag bits for x86-64.
+pub mod flags {
+    /// **Present** (P, bit 0).
+    ///
+    /// The CPU raises a `#PF` on any access to an entry where this bit is
+    /// clear.  Must be set for all entries in the active page-table walk.
+    pub const PRESENT: u64 = 1 << 0;
+
+    /// **Writable** (R/W, bit 1).
+    ///
+    /// When clear the mapped page (or the sub-table it points to) is
+    /// read-only.  A write triggers a `#PF` with error-code bit 1 set.
+    pub const WRITABLE: u64 = 1 << 1;
+
+    /// **User-accessible** (U/S, bit 2).
+    ///
+    /// When clear only ring-0 code can access the mapping.  Kernel page
+    /// tables leave this clear for all entries.
+    pub const USER_ACCESSIBLE: u64 = 1 << 2;
+
+    /// **Page-level write-through** (PWT, bit 3).
+    ///
+    /// Selects write-through caching for this mapping (versus write-back).
+    /// Rarely needed outside MMIO.
+    pub const WRITE_THROUGH: u64 = 1 << 3;
+
+    /// **Page-level cache disable** (PCD, bit 4).
+    ///
+    /// Disables caching entirely for this mapping.  Use for MMIO regions.
+    pub const NO_CACHE: u64 = 1 << 4;
+
+    /// **Accessed** (A, bit 5).
+    ///
+    /// Set by the CPU the first time this entry is used in a page-table walk.
+    /// Software may clear it to implement page-replacement algorithms.
+    pub const ACCESSED: u64 = 1 << 5;
+
+    /// **Dirty** (D, bit 6).
+    ///
+    /// Set by the CPU on the first write to the page.  Only meaningful in
+    /// PT (4 KiB) and PD huge-page entries; ignored in PML4 / PDPT.
+    pub const DIRTY: u64 = 1 << 6;
+
+    /// **Page size / huge page** (PS, bit 7).
+    ///
+    /// When set in a PD entry the entry maps a **2 MiB** page directly
+    /// (skipping the PT level).  When set in a PDPT entry it maps a **1 GiB**
+    /// page.  Must be clear in PML4 entries.
+    pub const HUGE_PAGE: u64 = 1 << 7;
+
+    /// **Global** (G, bit 8).
+    ///
+    /// When `CR4.PGE = 1`, global TLB entries survive a `MOV CR3` reload.
+    /// Use for kernel pages that are never removed from the address space.
+    pub const GLOBAL: u64 = 1 << 8;
+
+    /// **No-execute** (XD/NX, bit 63).
+    ///
+    /// Prevents instruction fetches from this page.  Requires `EFER.NXE = 1`.
+    /// Phase 1 does not enable NX; reserved for Phase 2+.
+    pub const NO_EXECUTE: u64 = 1 << 63;
+
+    /// Mask for the **physical address** bits in a page table entry.
+    ///
+    /// Bits [51:12] hold the physical page-frame number.  The remaining bits
+    /// carry flags, available bits, or must be zero.
+    pub const PHYS_ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
+}
+
+// ---------------------------------------------------------------------------
+// Entry type
+// ---------------------------------------------------------------------------
+
+/// A single 64-bit x86-64 page table entry.
+///
+/// The same struct is used at all four levels of the hierarchy:
+///
+/// | Level | Entry covers | `HUGE_PAGE` bit meaning    |
+/// |-------|-------------|----------------------------|
+/// | PML4  | 512 GiB     | must be 0 (reserved)       |
+/// | PDPT  | 1 GiB       | 1 → 1 GiB huge page        |
+/// | PD    | 2 MiB       | 1 → 2 MiB huge page        |
+/// | PT    | 4 KiB       | n/a (always a 4 KiB frame) |
+///
+/// Construction is always explicit via [`PageTableEntry::new`]; the default
+/// value is the absent entry `0` (present-bit clear).
+#[derive(Clone, Copy, Default)]
+#[repr(transparent)]
+pub struct PageTableEntry(u64);
+
+impl PageTableEntry {
+    /// An absent (not-present) entry.  The CPU treats this as an unmapped
+    /// address and raises `#PF` on access.
+    pub const EMPTY: Self = Self(0);
+
+    /// Create an entry mapping `phys_addr` with `entry_flags`.
+    ///
+    /// `phys_addr` is masked with [`flags::PHYS_ADDR_MASK`] before storing,
+    /// so the caller does not need to clear the low 12 bits manually.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // PD entry: 2 MiB huge page at physical 0x200000
+    /// let e = PageTableEntry::new(
+    ///     0x200000,
+    ///     flags::PRESENT | flags::WRITABLE | flags::HUGE_PAGE,
+    /// );
+    /// ```
+    #[inline]
+    pub const fn new(phys_addr: u64, entry_flags: u64) -> Self {
+        Self((phys_addr & flags::PHYS_ADDR_MASK) | entry_flags)
+    }
+
+    /// Return the raw 64-bit value of this entry.
+    #[inline]
+    pub const fn raw(self) -> u64 {
+        self.0
+    }
+
+    /// Return the physical address this entry points to, with flag bits masked
+    /// off.
+    #[inline]
+    pub const fn phys_addr(self) -> u64 {
+        self.0 & flags::PHYS_ADDR_MASK
+    }
+
+    /// Return `true` if the [`flags::PRESENT`] bit is set.
+    #[inline]
+    pub const fn is_present(self) -> bool {
+        self.0 & flags::PRESENT != 0
+    }
+
+    /// Return `true` if the [`flags::HUGE_PAGE`] bit is set.
+    #[inline]
+    pub const fn is_huge(self) -> bool {
+        self.0 & flags::HUGE_PAGE != 0
+    }
+
+    /// Return `true` if the [`flags::WRITABLE`] bit is set.
+    #[inline]
+    pub const fn is_writable(self) -> bool {
+        self.0 & flags::WRITABLE != 0
+    }
+}
+
+impl core::fmt::Debug for PageTableEntry {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "PageTableEntry(phys={:#012x}, flags={:#05x})",
+            self.phys_addr(),
+            self.0 & !flags::PHYS_ADDR_MASK,
+        )
+    }
+}

--- a/kernel/src/memory/paging/mapper.rs
+++ b/kernel/src/memory/paging/mapper.rs
@@ -1,0 +1,174 @@
+//! Kernel page-table mapper — Phase 1 implementation.
+//!
+//! [`KernelPageTable`] is the Phase-1 page table structure for Ferrous.
+//! It owns three [`PageTable`]s inline (PML4 + PDPT + PD) and sets up:
+//!
+//! - A **1 GiB identity map** covering physical addresses `[0, 1 GiB)` using
+//!   2 MiB huge pages, so the kernel continues executing at the same virtual
+//!   addresses after `CR3` is loaded.
+//! - A **higher-half alias** at `0xFFFF_8000_0000_0000` pointing to the same
+//!   physical range, establishing the higher-half window for Phase 2.
+//!
+//! # Page table layout
+//!
+//! ```text
+//! PML4[0]   ──→ PDPT   (identity: VA [0, 512 GiB))
+//! PML4[256] ──→ PDPT   (higher-half alias: VA [0xFFFF_8000_..., ...))
+//! PDPT[0]   ──→ PD     (covers VA [0, 1 GiB))
+//! PD[i]          ──→ 2 MiB huge page at physical i × 2 MiB
+//! ```
+//!
+//! With 512 PD entries × 2 MiB each = **1 GiB** is fully covered.
+//!
+//! # Phase scope
+//!
+//! This struct is intentionally minimal.  Phase 2 will replace it with a
+//! proper mapper that:
+//! - Allocates page-table frames from the physical frame allocator.
+//! - Supports 4 KiB pages for fine-grained mapping.
+//! - Tracks virtual-address-space regions.
+//! - Enforces execute-disable and write-protect on kernel code/data pages.
+
+use super::{
+    entry::{flags, PageTableEntry},
+    table::PageTable,
+};
+
+/// PML4 index for the higher-half window (`0xFFFF_8000_0000_0000`).
+///
+/// Bits [47:39] of `0xFFFF_8000_0000_0000` decode to `0x100` = 256.
+const HIGHER_HALF_PML4_IDX: usize = 256;
+
+/// Number of 2 MiB pages needed to cover 1 GiB of physical memory.
+///
+/// A single PD (512 entries) × 2 MiB per entry = 1 GiB exactly.
+const HUGE_PAGES_1GIB: usize = 512;
+
+/// Size of a 2 MiB huge page in bytes.
+const HUGE_PAGE_SIZE: u64 = 2 * 1024 * 1024; // 2 MiB
+
+/// The kernel's Phase-1 page table structure.
+///
+/// Holds a PML4, one PDPT, and one PD inline.  The entire struct is
+/// `4 KiB`-aligned so the physical address of each sub-table can be stored
+/// directly in the parent entry.
+///
+/// # Size
+///
+/// 3 × 4 KiB = **12 KiB**, resident in BSS (zero-initialised, no image bloat).
+///
+/// # Usage
+///
+/// ```ignore
+/// // Place in a static (BSS):
+/// static mut KERNEL_PAGE_TABLE: KernelPageTable = KernelPageTable::new();
+///
+/// // In kernel_main (single-threaded, interrupts disabled):
+/// // SAFETY: single-threaded, interrupts disabled, UEFI identity mapping active.
+/// let pml4_phys = unsafe {
+///     KERNEL_PAGE_TABLE.init();
+///     KERNEL_PAGE_TABLE.phys_pml4_addr()
+/// };
+/// unsafe { core::arch::asm!("mov cr3, {p}", p = in(reg) pml4_phys); }
+/// ```
+#[repr(C, align(4096))]
+pub struct KernelPageTable {
+    pml4: PageTable,
+    pdpt: PageTable,
+    pd: PageTable,
+}
+
+impl KernelPageTable {
+    /// Create a zeroed, uninitialised page table (all entries absent).
+    ///
+    /// Suitable for placement in a `static mut` — produces an all-zero BSS
+    /// pattern.  Must be followed by [`init`] before loading into CR3.
+    ///
+    /// [`init`]: KernelPageTable::init
+    pub const fn new() -> Self {
+        Self {
+            pml4: PageTable::new(),
+            pdpt: PageTable::new(),
+            pd: PageTable::new(),
+        }
+    }
+
+    /// Populate the page tables for Phase 1.
+    ///
+    /// Sets up:
+    ///
+    /// 1. `PD[0..511]` — 512 × 2 MiB huge pages covering `[0, 1 GiB)`.
+    /// 2. `PDPT[0]`    — points to the PD (covers VA `[0, 1 GiB)`).
+    /// 3. `PML4[0]`    — points to the PDPT (identity: VA `0` = PA `0`).
+    /// 4. `PML4[256]`  — points to the same PDPT (higher-half alias).
+    ///
+    /// # Safety
+    ///
+    /// - Must be called **exactly once** on this instance.
+    /// - Must be called while the CPU has a valid **identity mapping** covering
+    ///   the physical addresses of all three sub-tables.  Under UEFI this is
+    ///   always true before `CR3` is switched.
+    /// - `self` must reside in memory whose physical address equals its
+    ///   virtual address (UEFI guarantees this for the PE/COFF binary).
+    /// - Must be called **single-threaded** with interrupts disabled.
+    pub unsafe fn init(&mut self) {
+        // Zero all three tables to guarantee absent entries everywhere we
+        // don't explicitly set a mapping.  BSS is already zero but this guard
+        // makes the invariant explicit and protects against future callers
+        // that reuse an existing KernelPageTable instance.
+        self.pml4.zero();
+        self.pdpt.zero();
+        self.pd.zero();
+
+        // Step 1: fill PD with 2 MiB huge page entries covering [0, 1 GiB).
+        //
+        // Entry i maps physical address i × 2 MiB.
+        // Flags: Present | Writable | HugePage (PS=1).
+        for i in 0..HUGE_PAGES_1GIB {
+            let phys = (i as u64) * HUGE_PAGE_SIZE;
+            *self.pd.entry_mut(i) =
+                PageTableEntry::new(phys, flags::PRESENT | flags::WRITABLE | flags::HUGE_PAGE);
+        }
+
+        // Step 2: PDPT[0] → PD.
+        //
+        // Under UEFI identity mapping the virtual address of a static equals
+        // its physical address.  We use `core::ptr::addr_of!` to obtain a
+        // raw pointer without creating a mutable reference (which would be UB
+        // while we hold `&mut self`).
+        let pd_phys = core::ptr::addr_of!(self.pd) as u64;
+        *self.pdpt.entry_mut(0) = PageTableEntry::new(pd_phys, flags::PRESENT | flags::WRITABLE);
+
+        // Step 3: PML4[0] → PDPT  (identity window: VA 0..512 GiB).
+        let pdpt_phys = core::ptr::addr_of!(self.pdpt) as u64;
+        *self.pml4.entry_mut(0) = PageTableEntry::new(pdpt_phys, flags::PRESENT | flags::WRITABLE);
+
+        // Step 4: PML4[256] → same PDPT  (higher-half alias).
+        //
+        // PML4 index 256 covers virtual addresses starting at
+        // 0xFFFF_8000_0000_0000.  Reusing the same PDPT means
+        // VA 0xFFFF_8000_xxxx_xxxx aliases PA 0x0000_0000_xxxx_xxxx.
+        *self.pml4.entry_mut(HIGHER_HALF_PML4_IDX) =
+            PageTableEntry::new(pdpt_phys, flags::PRESENT | flags::WRITABLE);
+    }
+
+    /// Return the physical address of the PML4 table.
+    ///
+    /// This value must be written to `CR3` to activate these page tables.
+    /// Under UEFI identity mapping, the virtual address of a static equals
+    /// its physical address.
+    ///
+    /// # Safety
+    ///
+    /// Must be called while the UEFI identity mapping (VA == PA) is still
+    /// active, i.e., before the first `MOV CR3` that switches to our tables.
+    pub unsafe fn phys_pml4_addr(&self) -> u64 {
+        core::ptr::addr_of!(self.pml4) as u64
+    }
+}
+
+impl Default for KernelPageTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/kernel/src/memory/paging/mod.rs
+++ b/kernel/src/memory/paging/mod.rs
@@ -1,0 +1,197 @@
+//! Virtual memory management — address types and page table infrastructure.
+//!
+//! This module provides the building blocks for the x86-64 four-level
+//! page table hierarchy and type-safe virtual/physical address wrappers.
+//!
+//! # x86-64 paging overview (4-level mode)
+//!
+//! ```text
+//! Virtual Address (48-bit canonical)
+//!   Bits [47:39] → PML4 index    (512 GiB per entry)
+//!   Bits [38:30] → PDPT index    (  1 GiB per entry)
+//!   Bits [29:21] → PD index      (  2 MiB per entry; or 2 MiB huge page)
+//!   Bits [20:12] → PT index      (  4 KiB per entry)
+//!   Bits [11:0]  → page offset   (within the mapped frame)
+//! ```
+//!
+//! Phase 1 uses **2 MiB huge pages** (PS=1 in PD entries), skipping the PT
+//! level entirely.  Phase 2 will add 4 KiB pages, fine-grained access
+//! control, and demand paging.
+//!
+//! # Sub-modules
+//!
+//! | Module            | Contents                                       |
+//! |-------------------|------------------------------------------------|
+//! | [`entry`]         | [`PageTableEntry`] + [`flags`] constants       |
+//! | [`table`]         | [`PageTable`] — 512-entry, 4 KiB-aligned table |
+//! | [`mapper`]        | [`KernelPageTable`] — Phase-1 root structure   |
+
+pub mod entry;
+pub mod mapper;
+pub mod table;
+
+pub use entry::{flags, PageTableEntry};
+pub use mapper::KernelPageTable;
+pub use table::PageTable;
+
+// ---------------------------------------------------------------------------
+// Virtual address
+// ---------------------------------------------------------------------------
+
+/// A canonical x86-64 virtual address.
+///
+/// In 4-level paging mode, only bits [47:0] are significant.  Bits [63:48]
+/// must be identical copies of bit 47 — this is called the **canonical form**
+/// requirement.  Accessing a non-canonical address causes a `#GP` fault.
+///
+/// Two canonical ranges exist:
+///
+/// | Range                                       | Bits [63:48] |
+/// |---------------------------------------------|--------------|
+/// | `0x0000_0000_0000_0000..=0x0000_7FFF_FFFF_FFFF` | all-zero     |
+/// | `0xFFFF_8000_0000_0000..=0xFFFF_FFFF_FFFF_FFFF` | all-one      |
+///
+/// The gap between them is the **non-canonical hole**.  Ferrous places the
+/// kernel higher-half window at [`VirtualAddress::HIGHER_HALF_BASE`]
+/// (`0xFFFF_8000_0000_0000`).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct VirtualAddress(u64);
+
+impl VirtualAddress {
+    /// The first address of the kernel's higher-half window.
+    ///
+    /// Corresponds to PML4 index 256 in 4-level paging.
+    pub const HIGHER_HALF_BASE: Self = Self(0xFFFF_8000_0000_0000);
+
+    /// Construct a [`VirtualAddress`], returning `None` for non-canonical
+    /// values (bits [63:48] not a sign-extension of bit 47).
+    #[inline]
+    pub const fn try_new(addr: u64) -> Option<Self> {
+        // A canonical address has bits [63:48] either all-zero (bit 47 = 0)
+        // or all-one (bit 47 = 1).  Shift right 47 produces 0x0 or 0x1_FFFF.
+        let top = addr >> 47;
+        if top == 0 || top == 0x1_FFFF {
+            Some(Self(addr))
+        } else {
+            None
+        }
+    }
+
+    /// Construct without a canonicality check.
+    ///
+    /// # Safety
+    ///
+    /// `addr` must satisfy the canonical-form requirement (bits [63:48] are a
+    /// sign-extension of bit 47).  A non-canonical value stored here will
+    /// cause a `#GP` if the address is ever used in a memory reference.
+    #[inline]
+    pub const unsafe fn new_unchecked(addr: u64) -> Self {
+        Self(addr)
+    }
+
+    /// Return the raw 64-bit value.
+    #[inline]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// PML4 index: bits [47:39].
+    #[inline]
+    pub const fn pml4_index(self) -> usize {
+        ((self.0 >> 39) & 0x1FF) as usize
+    }
+
+    /// PDPT index: bits [38:30].
+    #[inline]
+    pub const fn pdpt_index(self) -> usize {
+        ((self.0 >> 30) & 0x1FF) as usize
+    }
+
+    /// PD index: bits [29:21].
+    #[inline]
+    pub const fn pd_index(self) -> usize {
+        ((self.0 >> 21) & 0x1FF) as usize
+    }
+
+    /// PT index: bits [20:12].
+    #[inline]
+    pub const fn pt_index(self) -> usize {
+        ((self.0 >> 12) & 0x1FF) as usize
+    }
+
+    /// 12-bit page offset: bits [11:0].
+    #[inline]
+    pub const fn page_offset(self) -> u64 {
+        self.0 & 0xFFF
+    }
+}
+
+impl core::fmt::Debug for VirtualAddress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "VirtualAddress({:#018x})", self.0)
+    }
+}
+
+impl core::fmt::Display for VirtualAddress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#018x}", self.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Physical address
+// ---------------------------------------------------------------------------
+
+/// A physical memory address.
+///
+/// On x86-64 the physical address space is up to 52 bits wide (MAXPHYADDR,
+/// queryable via CPUID).  Ferrous Phase 1 tracks up to 64 GiB (36 bits),
+/// matching the bitmap allocator's capacity.
+///
+/// Unlike [`VirtualAddress`], physical addresses have no canonical-form
+/// requirement — any value in the supported range is valid.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct PhysicalAddress(u64);
+
+impl PhysicalAddress {
+    /// Construct a `PhysicalAddress` from a raw value.
+    ///
+    /// No alignment or range validation is performed; the caller is
+    /// responsible for ensuring the value is a meaningful physical address.
+    #[inline]
+    pub const fn new(addr: u64) -> Self {
+        Self(addr)
+    }
+
+    /// Return the raw 64-bit value.
+    #[inline]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// Return `true` if the address is 4 KiB-aligned (bits [11:0] are zero).
+    #[inline]
+    pub const fn is_page_aligned(self) -> bool {
+        self.0 & 0xFFF == 0
+    }
+
+    /// Return `true` if the address is 2 MiB-aligned (bits [20:0] are zero).
+    #[inline]
+    pub const fn is_huge_page_aligned(self) -> bool {
+        self.0 & 0x1F_FFFF == 0
+    }
+}
+
+impl core::fmt::Debug for PhysicalAddress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "PhysicalAddress({:#018x})", self.0)
+    }
+}
+
+impl core::fmt::Display for PhysicalAddress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#018x}", self.0)
+    }
+}

--- a/kernel/src/memory/paging/table.rs
+++ b/kernel/src/memory/paging/table.rs
@@ -1,0 +1,94 @@
+//! The [`PageTable`] type — one level of the x86-64 page-table hierarchy.
+
+use super::entry::PageTableEntry;
+
+/// One level of the x86-64 four-level page table hierarchy.
+///
+/// A `PageTable` is exactly 4 KiB: 512 × 8-byte [`PageTableEntry`] values.
+/// It must be **4 KiB-aligned** so its physical address can be stored in a
+/// parent entry without losing low-order bits.
+///
+/// The same type is used at all four levels (PML4, PDPT, PD, PT).  The
+/// interpretation of individual entry flags varies by level; see
+/// [`entry::flags`].
+///
+/// # Static placement
+///
+/// `PageTable::new()` is a `const fn` returning all-zero (absent) entries.
+/// A `static mut PageTable` therefore lives in BSS — zero-initialised by the
+/// loader with no binary-image cost.
+///
+/// # Indexing
+///
+/// Use [`PageTable::entry`] and [`PageTable::entry_mut`] rather than
+/// direct array indexing so that bounds checks are expressed clearly.
+///
+/// [`entry::flags`]: super::entry::flags
+#[repr(C, align(4096))]
+pub struct PageTable {
+    entries: [PageTableEntry; 512],
+}
+
+impl PageTable {
+    /// Create an all-absent (not-present) page table.
+    ///
+    /// Suitable for placement in a `static` or `static mut` — produces the
+    /// all-zero BSS pattern, so no binary-image overhead.
+    pub const fn new() -> Self {
+        Self {
+            entries: [PageTableEntry::EMPTY; 512],
+        }
+    }
+
+    /// Set every entry to absent ([`PageTableEntry::EMPTY`]).
+    ///
+    /// Use this to reset a table that may have been populated previously.
+    pub fn zero(&mut self) {
+        for entry in &mut self.entries {
+            *entry = PageTableEntry::EMPTY;
+        }
+    }
+
+    /// Return a shared reference to the entry at `index`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= 512`.
+    #[inline]
+    pub fn entry(&self, index: usize) -> &PageTableEntry {
+        &self.entries[index]
+    }
+
+    /// Return a mutable reference to the entry at `index`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= 512`.
+    #[inline]
+    pub fn entry_mut(&mut self, index: usize) -> &mut PageTableEntry {
+        &mut self.entries[index]
+    }
+
+    /// Iterate over all 512 entries.
+    #[inline]
+    pub fn iter(&self) -> core::slice::Iter<'_, PageTableEntry> {
+        self.entries.iter()
+    }
+
+    /// Return the number of present entries in this table.
+    pub fn present_count(&self) -> usize {
+        self.entries.iter().filter(|e| e.is_present()).count()
+    }
+}
+
+impl Default for PageTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl core::fmt::Debug for PageTable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "PageTable({} present entries)", self.present_count())
+    }
+}


### PR DESCRIPTION
Closes #14

## Summary

- **`kernel/src/memory/paging/`** — canonical page table types for Phase 2+:
  - `VirtualAddress` with canonical-form validation (bits [63:48] sign-extension of bit 47) and index-extraction helpers (`pml4_index`, `pdpt_index`, `pd_index`, `pt_index`)
  - `PhysicalAddress` with alignment queries (`is_page_aligned`, `is_huge_page_aligned`)
  - `PageTableEntry` (transparent `u64`) + `flags` module (`PRESENT`, `WRITABLE`, `HUGE_PAGE`, `NO_EXECUTE`, `PHYS_ADDR_MASK`, …)
  - `PageTable` — `[PageTableEntry; 512]`, `repr(C, align(4096))`, `const fn new()` for BSS placement
  - `KernelPageTable` — PML4 + PDPT + PD inline (12 KiB BSS); `unsafe init()` populates 512 × 2 MiB huge pages covering `[0, 1 GiB)` + higher-half alias at `PML4[256]`

- **`boot/src/main.rs` — kernel_main Step 7**:
  - Three `repr(C, align(4096))` BSS statics: `PT_PML4`, `PT_PDPT`, `PT_PD`
  - `setup_page_tables()`: fills entries via `addr_of_mut!` raw pointer writes (no `static_mut_refs`), returns PML4 physical address
  - `MOV CR3` installs kernel page tables; CR3 readback verified
  - Higher-half alias `0xFFFF_8000_0000_0000` probed via `read_volatile` through both identity and higher-half VAs

## Page table layout

```
PML4[0]   ──→ PDPT
PML4[256] ──→ PDPT   (higher-half alias: VA 0xFFFF_8000_... → same PA)
PDPT[0]   ──→ PD
PD[0..511]──→ 2 MiB huge pages at PA 0, 2M, 4M, ... 1022M
```

## QEMU verification (`verify-boot.sh`)

```
[OK] CR3 loaded — kernel page tables active
[OK] CR3 readback verified (0xde1e000)
[INFO] Identity map: [0x0000000000000000, 0x0000000040000000)  1 GiB  2 MiB pages
[INFO] Higher-half:  [0xffff800000000000, 0xffff800040000000) → same physical
[OK] Higher-half alias verified (PML4[0] = 0xde1d023 via both windows)
[PASS] Boot verification PASSED
```

The `0xde1d023` value (`P|RW|ACCESSED`) confirms the CPU performed a real hardware page-table walk through the higher-half window — the Accessed bit was set by the hardware during the walk.

## Design notes

- **2 MiB huge pages** for Phase 1 — avoids allocating PT frames for every 4 KiB page; one PD covers 1 GiB with only 3 page-table frames total
- **Identity map is permanent in Phase 1** — no linker-script VMA offset yet; kernel continues running at identity VAs after CR3 switch (no far jump needed)
- **Higher-half alias established** — `PML4[256]` → same PDPT; Phase 2 will relocate the kernel binary to `0xFFFF_8000_0000_0000` and remove the low identity window
- **BSS page tables** — all three statics are zero-initialised by UEFI firmware; `const fn new()` returns all-zeros so no binary bloat
- **`addr_of_mut!` not `&mut`** — avoids creating Rust references to statics under construction; no `#[allow(static_mut_refs)]` needed in `setup_page_tables`

## Test plan

- [x] `cargo +nightly build -p ferrous-kernel` — kernel crate paging types compile clean
- [x] `cd boot && cargo +nightly build` — boot crate with Step 7 compiles clean
- [x] `bash scripts/verify-boot.sh` — QEMU boot passes all checks
- [x] CR3 readback == written value (hardware accepted our PML4)
- [x] Higher-half alias read returns same non-zero value as identity read