### PR TITLE
feat(paging): Phase 1.3.4 — 4 KiB page map/unmap/translate

### DIFF
--- a/boot/src/main.rs
+++ b/boot/src/main.rs
@@ -226,6 +226,259 @@ unsafe fn setup_page_tables() -> u64 {
 }
 
 // ---------------------------------------------------------------------------
+// Boot page-table helpers (Phase 1.3.4)
+//
+// The boot crate does not link against the kernel crate, so `ActivePageTable`
+// and `FrameAllocate` from `kernel/src/memory/paging/mapper.rs` are not
+// directly available here.  These inline helpers replicate the same logic
+// with the same safety invariants:
+//   - VA == PA (identity mapping from Step 7).
+//   - Single-threaded, interrupts disabled.
+//   - FRAME_ALLOC initialised in Step 6.
+// ---------------------------------------------------------------------------
+
+/// Walk the live page tables and translate `virt` to a physical address.
+///
+/// Handles 1 GiB (PDPT huge), 2 MiB (PD huge), and 4 KiB (PT) mappings.
+/// Returns `None` if any level is absent or the final entry is not present.
+///
+/// # Safety
+///
+/// Identity mapping must hold; CR3 must point to a valid PML4.
+unsafe fn boot_translate(virt: u64) -> Option<u64> {
+    let cr3: u64;
+    core::arch::asm!("mov {cr3}, cr3", cr3 = out(reg) cr3, options(nomem, nostack));
+    let pml4 = (cr3 & PT_PHYS_MASK) as *const u64;
+
+    let pml4e = pml4.add(((virt >> 39) & 0x1FF) as usize).read();
+    if pml4e & PT_PRESENT == 0 {
+        return None;
+    }
+
+    let pdpt = (pml4e & PT_PHYS_MASK) as *const u64;
+    let pdpte = pdpt.add(((virt >> 30) & 0x1FF) as usize).read();
+    if pdpte & PT_PRESENT == 0 {
+        return None;
+    }
+    if pdpte & PT_HUGE != 0 {
+        // 1 GiB huge page: PA = base | (virt & (1 GiB − 1))
+        return Some((pdpte & PT_PHYS_MASK) | (virt & 0x3FFF_FFFF));
+    }
+
+    let pd = (pdpte & PT_PHYS_MASK) as *const u64;
+    let pde = pd.add(((virt >> 21) & 0x1FF) as usize).read();
+    if pde & PT_PRESENT == 0 {
+        return None;
+    }
+    if pde & PT_HUGE != 0 {
+        // 2 MiB huge page: PA = base | (virt & (2 MiB − 1))
+        return Some((pde & PT_PHYS_MASK) | (virt & 0x1F_FFFF));
+    }
+
+    let pt = (pde & PT_PHYS_MASK) as *const u64;
+    let pte = pt.add(((virt >> 12) & 0x1FF) as usize).read();
+    if pte & PT_PRESENT == 0 {
+        return None;
+    }
+    Some((pte & PT_PHYS_MASK) | (virt & 0xFFF))
+}
+
+/// Ensure `entry` points to a child page table.
+///
+/// - If `entry` is already present, returns its physical address.
+/// - If absent, allocates a 4 KiB frame, zeroes it, installs
+///   `Present | Writable`, and returns the new frame address.
+///
+/// Returns `None` if the frame allocator is exhausted.
+///
+/// # Safety
+///
+/// Identity mapping must hold.
+#[allow(static_mut_refs)]
+unsafe fn boot_ensure_table(entry: *mut u64) -> Option<u64> {
+    let val = entry.read();
+    if val & PT_PRESENT != 0 {
+        return Some(val & PT_PHYS_MASK);
+    }
+    let frame = FRAME_ALLOC.allocate()?.start_address() as u64;
+    // Zero the newly allocated frame before installing it as a table.
+    let p = frame as *mut u64;
+    for i in 0..512usize {
+        p.add(i).write(0u64);
+    }
+    entry.write((frame & PT_PHYS_MASK) | PT_PRESENT | PT_WRITABLE);
+    Some(frame)
+}
+
+/// Map a single 4 KiB page at `virt` to physical frame `phys`.
+///
+/// Creates intermediate tables (PDPT, PD, PT) as needed via
+/// [`boot_ensure_table`].  Returns `false` if a frame allocation fails or
+/// the PT entry is already present.
+///
+/// **Does not handle huge-page splits** — the test VA (PML4[1] area) is in a
+/// region where no intermediate levels exist, so this simplified path is
+/// sufficient for the smoke test.
+///
+/// # Safety
+///
+/// - Identity mapping must hold.
+/// - `virt` must not be in a huge-page region.
+unsafe fn boot_map_4k(virt: u64, phys: u64, flags: u64) -> bool {
+    let cr3: u64;
+    core::arch::asm!("mov {cr3}, cr3", cr3 = out(reg) cr3, options(nomem, nostack));
+    let pml4 = (cr3 & PT_PHYS_MASK) as *mut u64;
+
+    let pml4e = pml4.add(((virt >> 39) & 0x1FF) as usize);
+    let pdpt_phys = match boot_ensure_table(pml4e) {
+        Some(p) => p,
+        None => return false,
+    };
+    let pdpt = pdpt_phys as *mut u64;
+
+    let pdpte = pdpt.add(((virt >> 30) & 0x1FF) as usize);
+    let pd_phys = match boot_ensure_table(pdpte) {
+        Some(p) => p,
+        None => return false,
+    };
+    let pd = pd_phys as *mut u64;
+
+    let pde = pd.add(((virt >> 21) & 0x1FF) as usize);
+    let pt_phys = match boot_ensure_table(pde) {
+        Some(p) => p,
+        None => return false,
+    };
+    let pt = pt_phys as *mut u64;
+
+    let pte = pt.add(((virt >> 12) & 0x1FF) as usize);
+    if pte.read() & PT_PRESENT != 0 {
+        return false; // already mapped
+    }
+    pte.write((phys & PT_PHYS_MASK) | flags);
+
+    // Invalidate the TLB entry for this specific VA.
+    core::arch::asm!(
+        "invlpg [{addr}]",
+        addr = in(reg) virt,
+        options(nostack, preserves_flags),
+    );
+    true
+}
+
+/// Unmap a single 4 KiB page at `virt`.
+///
+/// Clears the PT entry and issues `INVLPG`.  Returns `true` if the entry
+/// was present and cleared, `false` if the VA was not 4 KiB-mapped.
+///
+/// # Safety
+///
+/// Identity mapping must hold.
+unsafe fn boot_unmap_4k(virt: u64) -> bool {
+    let cr3: u64;
+    core::arch::asm!("mov {cr3}, cr3", cr3 = out(reg) cr3, options(nomem, nostack));
+    let pml4 = (cr3 & PT_PHYS_MASK) as *const u64;
+
+    let pml4e = pml4.add(((virt >> 39) & 0x1FF) as usize).read();
+    if pml4e & PT_PRESENT == 0 {
+        return false;
+    }
+    let pdpt = (pml4e & PT_PHYS_MASK) as *const u64;
+    let pdpte = pdpt.add(((virt >> 30) & 0x1FF) as usize).read();
+    if pdpte & PT_PRESENT == 0 || pdpte & PT_HUGE != 0 {
+        return false;
+    }
+    let pd = (pdpte & PT_PHYS_MASK) as *const u64;
+    let pde = pd.add(((virt >> 21) & 0x1FF) as usize).read();
+    if pde & PT_PRESENT == 0 || pde & PT_HUGE != 0 {
+        return false;
+    }
+    let pt = (pde & PT_PHYS_MASK) as *mut u64;
+    let pte = pt.add(((virt >> 12) & 0x1FF) as usize);
+    if pte.read() & PT_PRESENT == 0 {
+        return false;
+    }
+    pte.write(0u64);
+
+    core::arch::asm!(
+        "invlpg [{addr}]",
+        addr = in(reg) virt,
+        options(nostack, preserves_flags),
+    );
+    true
+}
+
+/// Split the 2 MiB huge PD entry covering `guard_va` into 512 × 4 KiB
+/// entries, then mark the 4 KiB page that contains `guard_va` non-present.
+///
+/// This is used in Step 8 to activate the kernel stack guard page: before
+/// this call the guard region is covered by the same 2 MiB huge page as
+/// the rest of the stack; after this call any access to the guard 4 KiB
+/// raises a `#PF`.
+///
+/// Returns `true` on success, `false` if FRAME_ALLOC is exhausted or the
+/// target PD entry is not a 2 MiB huge page.
+///
+/// # Safety
+///
+/// - Identity mapping must hold.
+/// - `guard_va` must be within a 2 MiB huge-page region (PS=1 in the PDE).
+#[allow(static_mut_refs)]
+unsafe fn boot_activate_guard_page(guard_va: u64) -> bool {
+    let cr3: u64;
+    core::arch::asm!("mov {cr3}, cr3", cr3 = out(reg) cr3, options(nomem, nostack));
+    let pml4 = (cr3 & PT_PHYS_MASK) as *const u64;
+
+    let pml4e = pml4.add(((guard_va >> 39) & 0x1FF) as usize).read();
+    if pml4e & PT_PRESENT == 0 {
+        return false;
+    }
+    let pdpt = (pml4e & PT_PHYS_MASK) as *const u64;
+    let pdpte = pdpt.add(((guard_va >> 30) & 0x1FF) as usize).read();
+    if pdpte & PT_PRESENT == 0 || pdpte & PT_HUGE != 0 {
+        return false; // absent or 1 GiB huge (not handled here)
+    }
+    let pd = (pdpte & PT_PHYS_MASK) as *mut u64;
+    let pde = pd.add(((guard_va >> 21) & 0x1FF) as usize);
+    let pde_val = pde.read();
+    if pde_val & PT_PRESENT == 0 || pde_val & PT_HUGE == 0 {
+        return false; // not a 2 MiB huge page
+    }
+
+    // Split: reproduce the 2 MiB region as 512 × 4 KiB PT entries.
+    let huge_base = pde_val & PT_PHYS_MASK; // 2 MiB-aligned PA
+    let base_flags = (pde_val & !PT_PHYS_MASK & !PT_HUGE) | PT_PRESENT;
+
+    let pt_frame = match FRAME_ALLOC.allocate() {
+        Some(f) => f.start_address() as u64,
+        None => return false,
+    };
+    let pt = pt_frame as *mut u64;
+    for i in 0..512usize {
+        let phys = huge_base + (i as u64) * 4096;
+        pt.add(i).write((phys & PT_PHYS_MASK) | base_flags);
+    }
+    // Replace the 2 MiB PDE with a pointer to the new PT.
+    pde.write((pt_frame & PT_PHYS_MASK) | PT_PRESENT | PT_WRITABLE);
+
+    // Flush the entire TLB — the 2 MiB entry is now stale.
+    let cr3_val: u64;
+    core::arch::asm!("mov {cr3}, cr3", cr3 = out(reg) cr3_val, options(nomem, nostack));
+    core::arch::asm!("mov cr3, {cr3}", cr3 = in(reg) cr3_val, options(nostack));
+
+    // Zero the PT entry for the guard page itself.
+    let guard_pt_idx = (guard_va >> 12) & 0x1FF;
+    pt.add(guard_pt_idx as usize).write(0u64);
+
+    // Targeted TLB invalidation for the guard VA.
+    core::arch::asm!(
+        "invlpg [{addr}]",
+        addr = in(reg) guard_va,
+        options(nostack, preserves_flags),
+    );
+    true
+}
+
+// ---------------------------------------------------------------------------
 // Panic handler
 // ---------------------------------------------------------------------------
 
@@ -847,6 +1100,164 @@ fn kernel_main(boot_info: &KernelBootInfo) -> ! {
     } else {
         serial_write_str("[WARN] Higher-half alias read zero — PML4[0] unexpectedly empty\r\n");
     }
+
+    // -----------------------------------------------------------------------
+    // Step 8: Page table management smoke test (Phase 1.3.4).
+    //
+    // Three sub-tests exercise the full map/translate/unmap surface and the
+    // huge-page splitting path:
+    //
+    //   A) translate — verify a known identity-mapped VA resolves correctly
+    //      through the 2 MiB huge-page path.
+    //   B) map / translate / unmap cycle — allocate a fresh frame, install
+    //      it at a VA in the unmapped PML4[1] region, verify translate
+    //      returns the expected PA, then unmap and confirm translate → None.
+    //   C) Guard page — split the 2 MiB huge page that covers the kernel
+    //      stack bottom, mark the guard 4 KiB non-present, confirm
+    //      translate → None for the guard VA and Some(_) above it.
+    //
+    // SAFETY invariants that hold for the entire step:
+    //   - VA == PA (identity mapping established in Step 7).
+    //   - Single-threaded, interrupts disabled.
+    //   - FRAME_ALLOC initialised in Step 6.
+    serial_write_str("\r\n[...] Page table management smoke test\r\n");
+
+    // --- Test A: translate a known identity-mapped VA ---
+    //
+    // PT_PML4 is a static in BSS; its VA equals its PA under identity map.
+    // The translate walk reaches it via a 2 MiB huge PD entry.
+    let known_va = core::ptr::addr_of!(PT_PML4) as u64;
+    match unsafe { boot_translate(known_va) } {
+        Some(pa) if pa == known_va => {
+            serial_write_str("[OK] A) translate: 0x");
+            serial_write_usize_hex(known_va as usize);
+            serial_write_str(" -> 0x");
+            serial_write_usize_hex(pa as usize);
+            serial_write_str(" (identity confirmed)\r\n");
+        }
+        Some(pa) => {
+            serial_write_str("[FAIL] A) translate PA mismatch: expected 0x");
+            serial_write_usize_hex(known_va as usize);
+            serial_write_str(" got 0x");
+            serial_write_usize_hex(pa as usize);
+            serial_write_str("\r\n");
+        }
+        None => {
+            serial_write_str("[FAIL] A) translate returned None for identity-mapped VA 0x");
+            serial_write_usize_hex(known_va as usize);
+            serial_write_str("\r\n");
+        }
+    }
+
+    // --- Test B: map / translate / unmap cycle ---
+    //
+    // VA 0x0000_0080_0000_0000 is PML4[1] — no intermediate tables exist
+    // for this region, so map_4k must create PDPT + PD + PT from scratch.
+    let test_va: u64 = 0x0000_0080_0000_0000;
+
+    // Allocate one free frame to serve as the mapped physical page.
+    #[allow(static_mut_refs)]
+    let test_frame: Option<u64> =
+        unsafe { FRAME_ALLOC.allocate().map(|f| f.start_address() as u64) };
+
+    match test_frame {
+        None => {
+            serial_write_str("[SKIP] B) map/unmap cycle: no free frames available\r\n");
+        }
+        Some(phys) => {
+            // Map.
+            let mapped = unsafe { boot_map_4k(test_va, phys, PT_PRESENT | PT_WRITABLE) };
+            if mapped {
+                serial_write_str("[OK] B) map_4k at 0x");
+                serial_write_usize_hex(test_va as usize);
+                serial_write_str(" -> phys 0x");
+                serial_write_usize_hex(phys as usize);
+                serial_write_str("\r\n");
+            } else {
+                serial_write_str("[FAIL] B) boot_map_4k returned false\r\n");
+            }
+
+            // Translate after map.
+            match unsafe { boot_translate(test_va) } {
+                Some(pa) if pa == phys => {
+                    serial_write_str("[OK] B) translate after map: 0x");
+                    serial_write_usize_hex(test_va as usize);
+                    serial_write_str(" -> 0x");
+                    serial_write_usize_hex(pa as usize);
+                    serial_write_str("\r\n");
+                }
+                Some(pa) => {
+                    serial_write_str("[FAIL] B) translate after map: expected 0x");
+                    serial_write_usize_hex(phys as usize);
+                    serial_write_str(" got 0x");
+                    serial_write_usize_hex(pa as usize);
+                    serial_write_str("\r\n");
+                }
+                None => {
+                    serial_write_str("[FAIL] B) translate after map returned None\r\n");
+                }
+            }
+
+            // Unmap.
+            let unmapped = unsafe { boot_unmap_4k(test_va) };
+            if unmapped {
+                serial_write_str("[OK] B) unmap_4k succeeded\r\n");
+            } else {
+                serial_write_str("[FAIL] B) boot_unmap_4k returned false\r\n");
+            }
+
+            // Translate after unmap — must be gone.
+            match unsafe { boot_translate(test_va) } {
+                None => {
+                    serial_write_str("[OK] B) translate after unmap: None\r\n");
+                }
+                Some(pa) => {
+                    serial_write_str("[FAIL] B) translate after unmap: expected None, got 0x");
+                    serial_write_usize_hex(pa as usize);
+                    serial_write_str("\r\n");
+                }
+            }
+        }
+    }
+
+    // --- Test C: guard page activation ---
+    //
+    // The kernel stack static starts at `stack_bottom`.  That address is
+    // within [0, 1 GiB), covered by a 2 MiB huge PD entry.  We split that
+    // entry and mark the first 4 KiB (the guard zone) non-present.
+    let guard_va = unsafe { core::ptr::addr_of!(KERNEL_STACK) as u64 };
+    let above_guard = guard_va + 4096; // first usable stack page
+
+    let split_ok = unsafe { boot_activate_guard_page(guard_va) };
+    if split_ok {
+        serial_write_str("[OK] C) 2 MiB page split, guard marked non-present\r\n");
+
+        // Guard VA must not be translatable.
+        match unsafe { boot_translate(guard_va) } {
+            None => {
+                serial_write_str("[OK] C) guard page translate -> None\r\n");
+            }
+            Some(pa) => {
+                serial_write_str("[FAIL] C) guard page still maps to 0x");
+                serial_write_usize_hex(pa as usize);
+                serial_write_str("\r\n");
+            }
+        }
+
+        // The page immediately above the guard must still be present.
+        match unsafe { boot_translate(above_guard) } {
+            Some(_) => {
+                serial_write_str("[OK] C) page above guard is still present\r\n");
+            }
+            None => {
+                serial_write_str("[FAIL] C) page above guard is not mapped!\r\n");
+            }
+        }
+    } else {
+        serial_write_str("[SKIP] C) guard page: insufficient memory for huge-page split\r\n");
+    }
+
+    serial_write_str("[OK] Page table management smoke test complete\r\n");
 
     serial_write_str(
         "\r\nKernel halting. Exception handlers active — any CPU exception will be caught.\r\n",

--- a/docs/MEMORY_ARCHITECTURE.md
+++ b/docs/MEMORY_ARCHITECTURE.md
@@ -590,7 +590,7 @@ pub enum MemoryError {
    - Boot Step 7 (`setup_page_tables`) populates three raw 4 KiB BSS statics via raw pointer writes (`addr_of_mut!`), loads PML4 physical address into CR3 (`MOV CR3`)
    - CR3 readback verified; higher-half alias confirmed via `read_volatile` through `0xFFFF_8000_...` VA; QEMU boot verification passes
 
-4. **Fine-Grained 4 KiB Page Mapping** -- COMPLETE (Phase 1.3.4, PR #TBD)
+4. **Fine-Grained 4 KiB Page Mapping** -- COMPLETE (Phase 1.3.4, PR #89)
    - `FrameAllocate` trait in `kernel::memory::paging::mapper` decouples page-walker from specific allocator
    - `ActivePageTable` type provides `map_4k`, `unmap_4k`, `translate` over the live CR3 tables
    - `MapError` (`OutOfMemory`, `AlreadyMapped`, `HugePageConflict`) and `UnmapError` (`NotMapped`, `HugePage`) as typed results
@@ -620,7 +620,7 @@ pub enum MemoryError {
 | UEFI memory map parsing | Complete (PR #64) | `MemoryMap`, `MemoryRegionKind`, `MemoryStats` in `ferrous-boot-info`; global `init`/`get` in `kernel::memory` |
 | Physical frame allocator (bitmap) | Complete (PR #87) | `BitmapFrameAllocator<262144>` in `ferrous-boot-info`; 2 MiB BSS bitmap; 52,311 free frames on QEMU |
 | Basic page table management (2 MiB huge pages) | Complete (PR #88) | `VirtualAddress`, `PhysicalAddress`, `PageTableEntry`, `PageTable`, `KernelPageTable`; identity + higher-half alias confirmed on QEMU |
-| Fine-grained 4 KiB page mapping | Complete (PR #TBD) | `ActivePageTable` with `map_4k`/`unmap_4k`/`translate`; `FrameAllocate` trait; `split_huge_pd`; `invlpg` + `flush_tlb_all`; guard page activated in boot Step 8 |
+| Fine-grained 4 KiB page mapping | Complete (PR #89) | `ActivePageTable` with `map_4k`/`unmap_4k`/`translate`; `FrameAllocate` trait; `split_huge_pd`; `invlpg` + `flush_tlb_all`; guard page activated in boot Step 8 |
 | Kernel heap allocator (linked list) | Pending (1.3.5) | Implements `GlobalAlloc`; migrate to buddy in Phase 2 |
 | Higher-half kernel binary (Phase 2) | Pending | Full ELF relocation to `0xFFFF_8000_0000_0000`; remove identity map |
 

--- a/docs/MEMORY_ARCHITECTURE.md
+++ b/docs/MEMORY_ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Ferrous Kernel - Memory Management Architecture
 
-**Version:** 0.4
+**Version:** 0.5
 **Date:** 2026-05-02
-**Status:** Phase 1 In Progress (1.3.1, 1.3.2, and 1.3.3 complete, 1.3.4-1.3.5 pending)
+**Status:** Phase 1 In Progress (1.3.1–1.3.4 complete, 1.3.5 pending)
 
 ---
 
@@ -589,9 +589,16 @@ pub enum MemoryError {
    - Phase 1 uses **2 MiB huge pages** (PS=1 in PD entries): `PML4[0]→PDPT[0]→PD[0..511]` covers [0, 1 GiB) identity; `PML4[256]→PDPT` creates higher-half alias at `0xFFFF_8000_0000_0000`
    - Boot Step 7 (`setup_page_tables`) populates three raw 4 KiB BSS statics via raw pointer writes (`addr_of_mut!`), loads PML4 physical address into CR3 (`MOV CR3`)
    - CR3 readback verified; higher-half alias confirmed via `read_volatile` through `0xFFFF_8000_...` VA; QEMU boot verification passes
-   - Note: identity map is permanent in Phase 1 (no linker script for kernel VMA yet); Phase 1.3.4 adds fine-grained 4 KiB page mappings
 
-4. **Switch to Higher-Half Kernel** -- Deferred to Phase 2
+4. **Fine-Grained 4 KiB Page Mapping** -- COMPLETE (Phase 1.3.4, PR #TBD)
+   - `FrameAllocate` trait in `kernel::memory::paging::mapper` decouples page-walker from specific allocator
+   - `ActivePageTable` type provides `map_4k`, `unmap_4k`, `translate` over the live CR3 tables
+   - `MapError` (`OutOfMemory`, `AlreadyMapped`, `HugePageConflict`) and `UnmapError` (`NotMapped`, `HugePage`) as typed results
+   - `split_huge_pd` automatically splits a 2 MiB PD entry into 512 × 4 KiB PT entries when `map_4k` hits a huge-page on the walk path; full TLB flush via CR3 reload after split
+   - `invlpg` (single-VA TLB invalidation after each map/unmap) and `flush_tlb_all` (CR3 reload for bulk splits)
+   - Boot Step 8 smoke test: (A) translate identity-mapped VA; (B) map/unmap round-trip at unmapped PML4[1] VA; (C) huge-page split activates KERNEL_STACK guard page (4 KiB non-present); QEMU boot verification passes
+
+5. **Switch to Higher-Half Kernel** -- Deferred to Phase 2
    - Phase 1 establishes the higher-half alias window but the kernel continues running at identity-mapped VAs (same binary, no linker-script VMA offset)
    - Full higher-half switch (kernel loaded at `0xFFFF_8000_0000_0000`, low identity map removed) happens when the kernel becomes a separate ELF binary in Phase 2
 
@@ -613,7 +620,7 @@ pub enum MemoryError {
 | UEFI memory map parsing | Complete (PR #64) | `MemoryMap`, `MemoryRegionKind`, `MemoryStats` in `ferrous-boot-info`; global `init`/`get` in `kernel::memory` |
 | Physical frame allocator (bitmap) | Complete (PR #87) | `BitmapFrameAllocator<262144>` in `ferrous-boot-info`; 2 MiB BSS bitmap; 52,311 free frames on QEMU |
 | Basic page table management (2 MiB huge pages) | Complete (PR #88) | `VirtualAddress`, `PhysicalAddress`, `PageTableEntry`, `PageTable`, `KernelPageTable`; identity + higher-half alias confirmed on QEMU |
-| Fine-grained 4 KiB page mapping | Pending (1.3.4) | Walk existing tables, allocate PT frames, map/unmap individual pages |
+| Fine-grained 4 KiB page mapping | Complete (PR #TBD) | `ActivePageTable` with `map_4k`/`unmap_4k`/`translate`; `FrameAllocate` trait; `split_huge_pd`; `invlpg` + `flush_tlb_all`; guard page activated in boot Step 8 |
 | Kernel heap allocator (linked list) | Pending (1.3.5) | Implements `GlobalAlloc`; migrate to buddy in Phase 2 |
 | Higher-half kernel binary (Phase 2) | Pending | Full ELF relocation to `0xFFFF_8000_0000_0000`; remove identity map |
 
@@ -622,7 +629,7 @@ pub enum MemoryError {
 - [x] Kernel can allocate and free physical frames
 - [x] Kernel owns its page tables (replaced UEFI firmware tables with Ferrous tables at boot)
 - [x] Higher-half window established at `0xFFFF_8000_0000_0000`
-- [ ] Kernel can map/unmap individual 4 KiB pages
+- [x] Kernel can map/unmap individual 4 KiB pages
 - [ ] Kernel heap allocation works (`Box`, `Vec` available)
 - [ ] Kernel binary loaded at higher-half VMA
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -116,7 +116,7 @@ Every milestone must advance these core goals:
 | 1.3.1 Parse UEFI Memory Map | #10 | Complete (PR #64) |
 | 1.3.2 Physical Memory Allocator | #13 | Complete (PR #87) |
 | 1.3.3 Virtual Memory Setup | #14 | Complete (PR #88) |
-| 1.3.4 Page Table Management | #19 | Complete (PR #TBD) |
+| 1.3.4 Page Table Management | #19 | Complete (PR #89) |
 | 1.3.5 Kernel Heap Allocator | #20 | Not Started |
 
 #### 1.4 - Core Infrastructure

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -97,6 +97,8 @@ Every milestone must advance these core goals:
 - `boot/src/main.rs` kernel_main Step 6 — initialises frame allocator, prints free/total frame counts and usable KiB, runs 3-frame smoke test (allocate, verify distinct + 4 KiB aligned, deallocate, verify count recovery); confirmed on QEMU (52,311 free frames / 204 MiB usable)
 - `kernel/src/memory/paging/` added — canonical page table types: `VirtualAddress` (canonical-form validated), `PhysicalAddress`, `PageTableEntry` + `flags` constants, `PageTable` ([PageTableEntry; 512], 4 KiB-aligned), `KernelPageTable` (PML4+PDPT+PD inline, Phase 1 mapper); `paging` added to `kernel::memory`
 - `boot/src/main.rs` kernel_main Step 7 — `setup_page_tables()` builds 3-level hierarchy (PML4→PDPT→PD) with 512 × 2 MiB huge pages covering [0, 1 GiB) identity + PML4[256] higher-half alias at 0xFFFF_8000_0000_0000; `MOV CR3` loads our tables; CR3 readback verified; higher-half alias probed via `read_volatile` (PML4[0]=0xde1d023 matching through both windows); QEMU boot verification passes
+- `kernel/src/memory/paging/mapper.rs` rewritten for Phase 1.3.4 — `FrameAllocate` trait decouples mapper from allocator; `ActivePageTable` provides `map_4k`, `unmap_4k`, `translate` over the live CR3 tables; `MapError`/`UnmapError` typed results; `split_huge_pd` automatically splits 2 MiB PD entries when `map_4k` targets a 4 KiB page within a huge region; `invlpg` + `flush_tlb_all` for TLB management; `iter_mut` added to `PageTable`; all types re-exported from `kernel::memory::paging`
+- `boot/src/main.rs` kernel_main Step 8 — inline smoke test (boot crate does not depend on kernel crate): (A) translate confirms identity-mapped VA resolves to same PA; (B) map_4k + translate + unmap_4k round-trip at unmapped PML4[1] VA; (C) huge-page split on the 2 MiB region covering KERNEL_STACK bottom — guard 4 KiB marked non-present, translate → None confirmed; QEMU boot verification passes
 
 #### 1.2 - Runtime Setup
 
@@ -114,7 +116,7 @@ Every milestone must advance these core goals:
 | 1.3.1 Parse UEFI Memory Map | #10 | Complete (PR #64) |
 | 1.3.2 Physical Memory Allocator | #13 | Complete (PR #87) |
 | 1.3.3 Virtual Memory Setup | #14 | Complete (PR #88) |
-| 1.3.4 Page Table Management | #19 | Not Started |
+| 1.3.4 Page Table Management | #19 | Complete (PR #TBD) |
 | 1.3.5 Kernel Heap Allocator | #20 | Not Started |
 
 #### 1.4 - Core Infrastructure

--- a/kernel/src/memory/paging/mapper.rs
+++ b/kernel/src/memory/paging/mapper.rs
@@ -1,38 +1,464 @@
-//! Kernel page-table mapper — Phase 1 implementation.
+//! Kernel page-table mapper.
 //!
-//! [`KernelPageTable`] is the Phase-1 page table structure for Ferrous.
-//! It owns three [`PageTable`]s inline (PML4 + PDPT + PD) and sets up:
+//! Two mappers are provided:
 //!
-//! - A **1 GiB identity map** covering physical addresses `[0, 1 GiB)` using
-//!   2 MiB huge pages, so the kernel continues executing at the same virtual
-//!   addresses after `CR3` is loaded.
-//! - A **higher-half alias** at `0xFFFF_8000_0000_0000` pointing to the same
-//!   physical range, establishing the higher-half window for Phase 2.
+//! | Type                | Purpose                                             |
+//! |---------------------|-----------------------------------------------------|
+//! | [`KernelPageTable`] | Phase-1 static bootstrap structure (PML4+PDPT+PD)  |
+//! | [`ActivePageTable`] | Live page-table walker — map, unmap, translate      |
 //!
-//! # Page table layout
+//! # Phase 1 invariant — identity mapping (VA == PA)
 //!
-//! ```text
-//! PML4[0]   ──→ PDPT   (identity: VA [0, 512 GiB))
-//! PML4[256] ──→ PDPT   (higher-half alias: VA [0xFFFF_8000_..., ...))
-//! PDPT[0]   ──→ PD     (covers VA [0, 1 GiB))
-//! PD[i]          ──→ 2 MiB huge page at physical i × 2 MiB
-//! ```
+//! All page-table manipulation in Phase 1 relies on the identity mapping
+//! established by [`KernelPageTable::init`]: every page-table frame is
+//! accessible at its physical address (virtual == physical).
 //!
-//! With 512 PD entries × 2 MiB each = **1 GiB** is fully covered.
+//! This invariant is **documented but not enforced** here; it holds because:
 //!
-//! # Phase scope
+//! 1. UEFI loads the PE/COFF binary with identity mapping.
+//! 2. [`KernelPageTable::init`] preserves identity for `[0, 1 GiB)`.
+//! 3. All newly allocated frames come from the physical frame allocator,
+//!    which operates within that range.
 //!
-//! This struct is intentionally minimal.  Phase 2 will replace it with a
-//! proper mapper that:
-//! - Allocates page-table frames from the physical frame allocator.
-//! - Supports 4 KiB pages for fine-grained mapping.
-//! - Tracks virtual-address-space regions.
-//! - Enforces execute-disable and write-protect on kernel code/data pages.
+//! Phase 2 will break this invariant (kernel will run at higher-half VAs),
+//! requiring a virtual-to-physical translation table for page-walker access.
 
 use super::{
     entry::{flags, PageTableEntry},
     table::PageTable,
+    VirtualAddress,
 };
+
+// ---------------------------------------------------------------------------
+// Allocation trait
+// ---------------------------------------------------------------------------
+
+/// A source of 4 KiB-aligned physical frames for page-table allocation.
+///
+/// Implementations wrap the global physical frame allocator (Phase 1) or a
+/// per-process allocator (Phase 2+).
+pub trait FrameAllocate {
+    /// Allocate one 4 KiB physical frame, returning its base address.
+    ///
+    /// The returned frame is uninitialized; callers that use it as a page
+    /// table must zero it before writing entries.
+    ///
+    /// Returns `None` if physical memory is exhausted.
+    fn allocate_frame(&mut self) -> Option<u64>;
+}
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+/// Errors returned by [`ActivePageTable::map_4k`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MapError {
+    /// The physical frame allocator returned `None` while creating an
+    /// intermediate page-table level.
+    OutOfMemory,
+
+    /// A 4 KiB mapping was requested for a virtual address that is already
+    /// mapped.  The existing physical address is provided.
+    AlreadyMapped(u64),
+
+    /// A 1 GiB huge PDPT entry covers the target virtual address.  Splitting
+    /// 1 GiB pages is not implemented in Phase 1.
+    HugePageConflict,
+}
+
+/// Errors returned by [`ActivePageTable::unmap_4k`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnmapError {
+    /// The virtual address has no 4 KiB mapping (the walk terminated early
+    /// due to an absent intermediate entry).
+    NotMapped,
+
+    /// The virtual address is covered by a huge page (2 MiB PD entry or
+    /// 1 GiB PDPT entry).  Use the appropriate huge-page unmap operation
+    /// (not yet implemented in Phase 1).
+    HugePage,
+}
+
+// ---------------------------------------------------------------------------
+// Internal walk error
+// ---------------------------------------------------------------------------
+
+enum WalkError {
+    NotMapped,
+    HugePage,
+}
+
+// ---------------------------------------------------------------------------
+// Free functions — TLB management
+// ---------------------------------------------------------------------------
+
+/// Invalidate the TLB entry for a single virtual address.
+///
+/// Must be called after modifying a page-table entry that is (or was)
+/// present, to ensure the CPU does not use a stale cached translation.
+///
+/// # Safety
+///
+/// - CPU must be in 64-bit paged mode.
+/// - `virt` should be a canonical virtual address, though the CPU silently
+///   ignores `INVLPG` on non-canonical addresses.
+pub unsafe fn invlpg(virt: u64) {
+    core::arch::asm!(
+        "invlpg [{addr}]",
+        addr = in(reg) virt,
+        options(nostack, preserves_flags),
+    );
+}
+
+/// Flush the entire TLB by reloading CR3.
+///
+/// More expensive than a targeted [`invlpg`], but necessary after bulk
+/// changes such as splitting a 2 MiB huge page into 512 × 4 KiB entries,
+/// where 512 individual `INVLPG` calls would be wasteful.
+///
+/// # Safety
+///
+/// - CPU must have valid page tables loaded.
+/// - The identity mapping must cover the instruction stream so execution
+///   continues correctly after the reload.
+pub unsafe fn flush_tlb_all() {
+    let cr3: u64;
+    core::arch::asm!(
+        "mov {cr3}, cr3",
+        cr3 = out(reg) cr3,
+        options(nomem, nostack),
+    );
+    core::arch::asm!(
+        "mov cr3, {cr3}",
+        cr3 = in(reg) cr3,
+        options(nostack),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Ensure `entry` points to a child [`PageTable`].
+///
+/// - If `entry` is already present (and not a huge page), returns its
+///   physical address unchanged.
+/// - If `entry` is absent, allocates a frame, zeroes it, and installs
+///   `Present | Writable` into `entry`.
+///
+/// # Safety
+///
+/// Identity mapping (VA == PA) must hold for the newly allocated frame.
+unsafe fn ensure_table<A: FrameAllocate>(
+    entry: &mut PageTableEntry,
+    alloc: &mut A,
+) -> Result<u64, MapError> {
+    if entry.is_present() {
+        Ok(entry.phys_addr())
+    } else {
+        let frame = alloc.allocate_frame().ok_or(MapError::OutOfMemory)?;
+        // Zero the frame: it may contain garbage from a previous allocation.
+        // SAFETY: frame is a valid, exclusively-owned 4 KiB physical frame;
+        // identity mapping makes the physical address directly addressable.
+        let table = &mut *(frame as *mut PageTable);
+        table.zero();
+        *entry = PageTableEntry::new(frame, flags::PRESENT | flags::WRITABLE);
+        Ok(frame)
+    }
+}
+
+/// Split a 2 MiB PD huge-page entry into 512 × 4 KiB PT entries.
+///
+/// The new PT is populated with entries that reproduce the original 2 MiB
+/// mapping at 4 KiB granularity, preserving all flags except `HUGE_PAGE`.
+/// The PD entry is then updated to point to the new PT.
+///
+/// After installing the PT, the entire TLB is flushed (via [`flush_tlb_all`])
+/// because the 2 MiB TLB entry is now stale — 512 individual `INVLPG` calls
+/// would be correct but unnecessarily verbose for Phase 1.
+///
+/// # Safety
+///
+/// - `pde` must point to a present, huge (2 MiB) PD entry.
+/// - Identity mapping must hold.
+/// - `alloc` must return valid 4 KiB frames.
+unsafe fn split_huge_pd<A: FrameAllocate>(
+    pde: &mut PageTableEntry,
+    alloc: &mut A,
+) -> Result<(), MapError> {
+    debug_assert!(
+        pde.is_present() && pde.is_huge(),
+        "split_huge_pd: entry is not a present 2 MiB huge page"
+    );
+
+    let huge_base = pde.phys_addr(); // 2 MiB-aligned PA of the original region.
+
+    // Carry over existing flags (P, RW, U/S, PWT, PCD, G, XD) but strip
+    // HUGE_PAGE (PS), which has no meaning in a PT entry.
+    let base_flags = (pde.raw() & !flags::PHYS_ADDR_MASK & !flags::HUGE_PAGE) | flags::PRESENT;
+
+    let pt_frame = alloc.allocate_frame().ok_or(MapError::OutOfMemory)?;
+    // SAFETY: pt_frame is a fresh, exclusively-owned frame; VA == PA.
+    let pt = &mut *(pt_frame as *mut PageTable);
+
+    // Each of the 512 PT entries maps one 4 KiB subpage of the original
+    // 2 MiB region.  Entry i covers physical address huge_base + i×4 KiB.
+    for (i, entry) in pt.iter_mut().enumerate() {
+        let phys = huge_base + (i as u64) * 4096;
+        *entry = PageTableEntry::new(phys, base_flags);
+    }
+
+    // Replace the 2 MiB PD entry with a pointer to the new PT.
+    *pde = PageTableEntry::new(pt_frame, flags::PRESENT | flags::WRITABLE);
+
+    // Flush all TLB entries — the 2 MiB entry is stale after this change.
+    flush_tlb_all();
+
+    Ok(())
+}
+
+/// Walk the active page tables down to the PT entry for `virt`.
+///
+/// Returns a mutable reference to the PT entry, or a [`WalkError`] if any
+/// intermediate level is absent or is a huge page that blocks the walk.
+///
+/// # Safety
+///
+/// Identity mapping must hold; CR3 must point to a valid PML4.
+unsafe fn pt_entry_mut(virt: VirtualAddress) -> Result<&'static mut PageTableEntry, WalkError> {
+    // Read the current CR3 to obtain the PML4 physical address.
+    let cr3: u64;
+    core::arch::asm!("mov {cr3}, cr3", cr3 = out(reg) cr3, options(nomem, nostack));
+    let pml4_phys = cr3 & flags::PHYS_ADDR_MASK;
+
+    // SAFETY: pml4_phys is a valid 4 KiB-aligned frame; VA == PA.
+    let pml4 = &mut *(pml4_phys as *mut PageTable);
+    let pml4e = pml4.entry_mut(virt.pml4_index());
+    if !pml4e.is_present() {
+        return Err(WalkError::NotMapped);
+    }
+
+    let pdpt = &mut *(pml4e.phys_addr() as *mut PageTable);
+    let pdpte = pdpt.entry_mut(virt.pdpt_index());
+    if !pdpte.is_present() {
+        return Err(WalkError::NotMapped);
+    }
+    if pdpte.is_huge() {
+        return Err(WalkError::HugePage); // 1 GiB page — cannot walk further.
+    }
+
+    let pd = &mut *(pdpte.phys_addr() as *mut PageTable);
+    let pde = pd.entry_mut(virt.pd_index());
+    if !pde.is_present() {
+        return Err(WalkError::NotMapped);
+    }
+    if pde.is_huge() {
+        return Err(WalkError::HugePage); // 2 MiB page — cannot walk to PT level.
+    }
+
+    let pt = &mut *(pde.phys_addr() as *mut PageTable);
+    Ok(pt.entry_mut(virt.pt_index()))
+}
+
+// ---------------------------------------------------------------------------
+// ActivePageTable
+// ---------------------------------------------------------------------------
+
+/// Live page-table walker for the currently-loaded CR3.
+///
+/// Provides [`map_4k`], [`unmap_4k`], and [`translate`] over the active
+/// page tables.  Huge-page splits are performed automatically when
+/// [`map_4k`] encounters a 2 MiB PD entry on the path to the target VA.
+///
+/// # Phase 1 invariant — identity mapping (VA == PA)
+///
+/// All page-table frames are accessed by casting their physical addresses
+/// directly to raw pointers.  This is correct only while the identity
+/// mapping is active (VA == PA for all page-table frames).  Phase 2 will
+/// need a separate virtual window for page-walker access.
+///
+/// # Thread safety
+///
+/// Phase 1 is single-core with interrupts disabled.  There is no locking.
+/// Phase 2 will wrap this in a spinlock-guarded `AddressSpace`.
+///
+/// [`map_4k`]: ActivePageTable::map_4k
+/// [`unmap_4k`]: ActivePageTable::unmap_4k
+/// [`translate`]: ActivePageTable::translate
+pub struct ActivePageTable;
+
+impl ActivePageTable {
+    /// Borrow the currently-active page tables.
+    ///
+    /// # Safety
+    ///
+    /// - The CPU must be in 64-bit paged mode (CR0.PG = 1).
+    /// - The identity-mapping invariant must hold: every page-table frame is
+    ///   accessible at its physical address (VA == PA).
+    /// - The caller must guarantee exclusive access (Phase 1: single-core,
+    ///   interrupts disabled).
+    pub unsafe fn current() -> Self {
+        Self
+    }
+
+    /// Translate a virtual address to its physical address.
+    ///
+    /// Walks the PML4 → PDPT → PD → PT hierarchy, correctly handling:
+    /// - 1 GiB huge pages (PDPT entry with PS=1)
+    /// - 2 MiB huge pages (PD entry with PS=1)
+    /// - 4 KiB pages (PT entry)
+    ///
+    /// Returns `None` if any level is absent or if the final PT entry has
+    /// Present=0.
+    ///
+    /// # Safety
+    ///
+    /// Identity mapping must hold; CR3 must point to a valid PML4.
+    pub unsafe fn translate(&self, virt: VirtualAddress) -> Option<u64> {
+        let cr3: u64;
+        core::arch::asm!("mov {cr3}, cr3", cr3 = out(reg) cr3, options(nomem, nostack));
+        let pml4 = &*((cr3 & flags::PHYS_ADDR_MASK) as *const PageTable);
+
+        let pml4e = pml4.entry(virt.pml4_index());
+        if !pml4e.is_present() {
+            return None;
+        }
+
+        let pdpt = &*(pml4e.phys_addr() as *const PageTable);
+        let pdpte = pdpt.entry(virt.pdpt_index());
+        if !pdpte.is_present() {
+            return None;
+        }
+        if pdpte.is_huge() {
+            // 1 GiB huge page: PA = pdpte.phys_addr() | (virt & 0x3FFF_FFFF).
+            return Some(pdpte.phys_addr() | (virt.as_u64() & 0x3FFF_FFFF));
+        }
+
+        let pd = &*(pdpte.phys_addr() as *const PageTable);
+        let pde = pd.entry(virt.pd_index());
+        if !pde.is_present() {
+            return None;
+        }
+        if pde.is_huge() {
+            // 2 MiB huge page: PA = pde.phys_addr() | (virt & 0x1F_FFFF).
+            return Some(pde.phys_addr() | (virt.as_u64() & 0x1F_FFFF));
+        }
+
+        let pt = &*(pde.phys_addr() as *const PageTable);
+        let pte = pt.entry(virt.pt_index());
+        if !pte.is_present() {
+            return None;
+        }
+        Some(pte.phys_addr() | virt.page_offset())
+    }
+
+    /// Map a 4 KiB virtual page to a physical frame.
+    ///
+    /// Creates intermediate page-table levels (PDPT, PD, PT) as needed by
+    /// allocating frames from `alloc`.  If a 2 MiB PD huge-page entry
+    /// covers the target VA, it is automatically split into 512 × 4 KiB
+    /// entries before the new mapping is installed.
+    ///
+    /// # Errors
+    ///
+    /// - [`MapError::OutOfMemory`] — frame allocation failed.
+    /// - [`MapError::AlreadyMapped`] — the PT entry is already present.
+    /// - [`MapError::HugePageConflict`] — a 1 GiB PDPT huge page covers the
+    ///   target VA; splitting 1 GiB pages is not supported in Phase 1.
+    ///
+    /// # Safety
+    ///
+    /// - Identity mapping must hold.
+    /// - `phys` must be a 4 KiB-aligned physical address of a valid frame.
+    /// - `flags` must include at least [`flags::PRESENT`].
+    /// - The caller must guarantee that no other code is concurrently
+    ///   modifying the page tables (Phase 1: single-core, interrupts off).
+    pub unsafe fn map_4k<A: FrameAllocate>(
+        &mut self,
+        virt: VirtualAddress,
+        phys: u64,
+        entry_flags: u64,
+        alloc: &mut A,
+    ) -> Result<(), MapError> {
+        let cr3: u64;
+        core::arch::asm!("mov {cr3}, cr3", cr3 = out(reg) cr3, options(nomem, nostack));
+        let pml4 = &mut *((cr3 & flags::PHYS_ADDR_MASK) as *mut PageTable);
+
+        // Level 1: ensure PDPT exists.
+        let pml4e = pml4.entry_mut(virt.pml4_index());
+        let pdpt_phys = ensure_table(pml4e, alloc)?;
+
+        // Level 2: ensure PD exists (reject 1 GiB pages — not splittable yet).
+        let pdpt = &mut *(pdpt_phys as *mut PageTable);
+        let pdpte = pdpt.entry_mut(virt.pdpt_index());
+        if pdpte.is_present() && pdpte.is_huge() {
+            return Err(MapError::HugePageConflict);
+        }
+        let pd_phys = ensure_table(pdpte, alloc)?;
+
+        // Level 3: handle 2 MiB huge page — split if necessary, then ensure PT.
+        let pd = &mut *(pd_phys as *mut PageTable);
+        let pde = pd.entry_mut(virt.pd_index());
+        if pde.is_present() && pde.is_huge() {
+            split_huge_pd(pde, alloc)?;
+        }
+        let pt_phys = ensure_table(pde, alloc)?;
+
+        // Level 4: install the 4 KiB mapping.
+        let pt = &mut *(pt_phys as *mut PageTable);
+        let pte = pt.entry_mut(virt.pt_index());
+        if pte.is_present() {
+            return Err(MapError::AlreadyMapped(pte.phys_addr()));
+        }
+        *pte = PageTableEntry::new(phys, entry_flags);
+
+        // Invalidate the TLB entry for this specific VA.
+        invlpg(virt.as_u64());
+
+        Ok(())
+    }
+
+    /// Unmap a 4 KiB virtual page and invalidate its TLB entry.
+    ///
+    /// Clears the PT entry and issues an [`invlpg`] for the given VA.
+    /// The physical frame that was mapped is **not** deallocated — the
+    /// caller is responsible for returning it to the frame allocator if
+    /// appropriate.
+    ///
+    /// # Errors
+    ///
+    /// - [`UnmapError::NotMapped`] — the VA has no present 4 KiB mapping.
+    /// - [`UnmapError::HugePage`] — the VA is covered by a huge page.
+    ///
+    /// # Returns
+    ///
+    /// On success, the physical address of the frame that was unmapped.
+    ///
+    /// # Safety
+    ///
+    /// - Identity mapping must hold.
+    /// - The caller must ensure no concurrent modification of the page tables.
+    pub unsafe fn unmap_4k(&mut self, virt: VirtualAddress) -> Result<u64, UnmapError> {
+        match pt_entry_mut(virt) {
+            Ok(pte) => {
+                if !pte.is_present() {
+                    return Err(UnmapError::NotMapped);
+                }
+                let phys = pte.phys_addr();
+                *pte = PageTableEntry::EMPTY;
+                invlpg(virt.as_u64());
+                Ok(phys)
+            }
+            Err(WalkError::NotMapped) => Err(UnmapError::NotMapped),
+            Err(WalkError::HugePage) => Err(UnmapError::HugePage),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KernelPageTable  (Phase-1 bootstrap structure — unchanged from 1.3.3)
+// ---------------------------------------------------------------------------
 
 /// PML4 index for the higher-half window (`0xFFFF_8000_0000_0000`).
 ///
@@ -40,37 +466,29 @@ use super::{
 const HIGHER_HALF_PML4_IDX: usize = 256;
 
 /// Number of 2 MiB pages needed to cover 1 GiB of physical memory.
-///
-/// A single PD (512 entries) × 2 MiB per entry = 1 GiB exactly.
 const HUGE_PAGES_1GIB: usize = 512;
 
 /// Size of a 2 MiB huge page in bytes.
-const HUGE_PAGE_SIZE: u64 = 2 * 1024 * 1024; // 2 MiB
+const HUGE_PAGE_SIZE: u64 = 2 * 1024 * 1024;
 
-/// The kernel's Phase-1 page table structure.
+/// The kernel's Phase-1 bootstrap page table structure.
 ///
-/// Holds a PML4, one PDPT, and one PD inline.  The entire struct is
-/// `4 KiB`-aligned so the physical address of each sub-table can be stored
-/// directly in the parent entry.
+/// Holds a PML4, one PDPT, and one PD inline (12 KiB BSS).  Call
+/// [`init`] to populate the tables and then load the PML4 address into CR3.
 ///
-/// # Size
+/// After [`init`] completes, use [`ActivePageTable`] to perform all
+/// subsequent map/unmap/translate operations.
 ///
-/// 3 × 4 KiB = **12 KiB**, resident in BSS (zero-initialised, no image bloat).
+/// # Layout after `init`
 ///
-/// # Usage
-///
-/// ```ignore
-/// // Place in a static (BSS):
-/// static mut KERNEL_PAGE_TABLE: KernelPageTable = KernelPageTable::new();
-///
-/// // In kernel_main (single-threaded, interrupts disabled):
-/// // SAFETY: single-threaded, interrupts disabled, UEFI identity mapping active.
-/// let pml4_phys = unsafe {
-///     KERNEL_PAGE_TABLE.init();
-///     KERNEL_PAGE_TABLE.phys_pml4_addr()
-/// };
-/// unsafe { core::arch::asm!("mov cr3, {p}", p = in(reg) pml4_phys); }
+/// ```text
+/// PML4[0]   ──→ PDPT   (identity: VA [0, 512 GiB) = PA [0, 512 GiB))
+/// PML4[256] ──→ PDPT   (higher-half alias: 0xFFFF_8000_0000_0000)
+/// PDPT[0]   ──→ PD     (covers VA [0, 1 GiB))
+/// PD[0..511]──→ 2 MiB huge pages at PA 0, 2M, 4M, …
 /// ```
+///
+/// [`init`]: KernelPageTable::init
 #[repr(C, align(4096))]
 pub struct KernelPageTable {
     pml4: PageTable,
@@ -95,73 +513,36 @@ impl KernelPageTable {
 
     /// Populate the page tables for Phase 1.
     ///
-    /// Sets up:
-    ///
-    /// 1. `PD[0..511]` — 512 × 2 MiB huge pages covering `[0, 1 GiB)`.
-    /// 2. `PDPT[0]`    — points to the PD (covers VA `[0, 1 GiB)`).
-    /// 3. `PML4[0]`    — points to the PDPT (identity: VA `0` = PA `0`).
-    /// 4. `PML4[256]`  — points to the same PDPT (higher-half alias).
-    ///
     /// # Safety
     ///
     /// - Must be called **exactly once** on this instance.
-    /// - Must be called while the CPU has a valid **identity mapping** covering
-    ///   the physical addresses of all three sub-tables.  Under UEFI this is
-    ///   always true before `CR3` is switched.
-    /// - `self` must reside in memory whose physical address equals its
-    ///   virtual address (UEFI guarantees this for the PE/COFF binary).
+    /// - Must be called while identity mapping (VA == PA) is in effect.
     /// - Must be called **single-threaded** with interrupts disabled.
     pub unsafe fn init(&mut self) {
-        // Zero all three tables to guarantee absent entries everywhere we
-        // don't explicitly set a mapping.  BSS is already zero but this guard
-        // makes the invariant explicit and protects against future callers
-        // that reuse an existing KernelPageTable instance.
         self.pml4.zero();
         self.pdpt.zero();
         self.pd.zero();
 
-        // Step 1: fill PD with 2 MiB huge page entries covering [0, 1 GiB).
-        //
-        // Entry i maps physical address i × 2 MiB.
-        // Flags: Present | Writable | HugePage (PS=1).
         for i in 0..HUGE_PAGES_1GIB {
             let phys = (i as u64) * HUGE_PAGE_SIZE;
             *self.pd.entry_mut(i) =
                 PageTableEntry::new(phys, flags::PRESENT | flags::WRITABLE | flags::HUGE_PAGE);
         }
 
-        // Step 2: PDPT[0] → PD.
-        //
-        // Under UEFI identity mapping the virtual address of a static equals
-        // its physical address.  We use `core::ptr::addr_of!` to obtain a
-        // raw pointer without creating a mutable reference (which would be UB
-        // while we hold `&mut self`).
         let pd_phys = core::ptr::addr_of!(self.pd) as u64;
         *self.pdpt.entry_mut(0) = PageTableEntry::new(pd_phys, flags::PRESENT | flags::WRITABLE);
 
-        // Step 3: PML4[0] → PDPT  (identity window: VA 0..512 GiB).
         let pdpt_phys = core::ptr::addr_of!(self.pdpt) as u64;
         *self.pml4.entry_mut(0) = PageTableEntry::new(pdpt_phys, flags::PRESENT | flags::WRITABLE);
-
-        // Step 4: PML4[256] → same PDPT  (higher-half alias).
-        //
-        // PML4 index 256 covers virtual addresses starting at
-        // 0xFFFF_8000_0000_0000.  Reusing the same PDPT means
-        // VA 0xFFFF_8000_xxxx_xxxx aliases PA 0x0000_0000_xxxx_xxxx.
         *self.pml4.entry_mut(HIGHER_HALF_PML4_IDX) =
             PageTableEntry::new(pdpt_phys, flags::PRESENT | flags::WRITABLE);
     }
 
-    /// Return the physical address of the PML4 table.
-    ///
-    /// This value must be written to `CR3` to activate these page tables.
-    /// Under UEFI identity mapping, the virtual address of a static equals
-    /// its physical address.
+    /// Return the physical address of the PML4 — write this to CR3.
     ///
     /// # Safety
     ///
-    /// Must be called while the UEFI identity mapping (VA == PA) is still
-    /// active, i.e., before the first `MOV CR3` that switches to our tables.
+    /// Must be called while identity mapping (VA == PA) is still active.
     pub unsafe fn phys_pml4_addr(&self) -> u64 {
         core::ptr::addr_of!(self.pml4) as u64
     }

--- a/kernel/src/memory/paging/mod.rs
+++ b/kernel/src/memory/paging/mod.rs
@@ -31,7 +31,9 @@ pub mod mapper;
 pub mod table;
 
 pub use entry::{flags, PageTableEntry};
-pub use mapper::KernelPageTable;
+pub use mapper::{
+    flush_tlb_all, invlpg, ActivePageTable, FrameAllocate, KernelPageTable, MapError, UnmapError,
+};
 pub use table::PageTable;
 
 // ---------------------------------------------------------------------------

--- a/kernel/src/memory/paging/table.rs
+++ b/kernel/src/memory/paging/table.rs
@@ -69,10 +69,16 @@ impl PageTable {
         &mut self.entries[index]
     }
 
-    /// Iterate over all 512 entries.
+    /// Iterate over all 512 entries (shared).
     #[inline]
     pub fn iter(&self) -> core::slice::Iter<'_, PageTableEntry> {
         self.entries.iter()
+    }
+
+    /// Iterate over all 512 entries (mutable).
+    #[inline]
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, PageTableEntry> {
+        self.entries.iter_mut()
     }
 
     /// Return the number of present entries in this table.


### PR DESCRIPTION
## Summary

Implements Phase 1.3.4 (issue #19): fine-grained 4 KiB page table management over the live CR3 tables.

**Kernel crate (`kernel/src/memory/paging/`)**
- `FrameAllocate` trait — decouples the page-table walker from the physical frame allocator; wraps `BitmapFrameAllocator` in boot
- `ActivePageTable` struct with three operations:
  - `map_4k(virt, phys, flags, alloc)` — walks PML4→PDPT→PD→PT, creates absent intermediate tables via `ensure_table`, automatically splits 2 MiB PD huge pages via `split_huge_pd`, installs the PT entry, calls `INVLPG`
  - `unmap_4k(virt)` — clears the PT entry and calls `INVLPG`; returns the unmapped PA
  - `translate(virt)` — full walk, handles 1 GiB / 2 MiB / 4 KiB pages, returns `None` for any absent level
- `MapError` (`OutOfMemory`, `AlreadyMapped`, `HugePageConflict`) and `UnmapError` (`NotMapped`, `HugePage`) typed results
- `split_huge_pd` — allocates a PT frame, fills 512 × 4 KiB entries preserving original flags, flushes TLB via CR3 reload; 1 GiB PDPT huge pages return `HugePageConflict` (splitting deferred to Phase 2)
- `invlpg` and `flush_tlb_all` free functions for TLB management
- `iter_mut` added to `PageTable`
- All new types re-exported from `kernel::memory::paging`

**Boot crate (`boot/src/main.rs`) — Step 8 smoke test**

The boot crate does not depend on the kernel crate, so the smoke test uses equivalent inline helpers (`boot_translate`, `boot_map_4k`, `boot_unmap_4k`, `boot_activate_guard_page`):

- **Test A** — translate a known identity-mapped VA (`&PT_PML4`); confirms 2 MiB huge-page path returns `VA == PA`
- **Test B** — allocate a free frame, map it at `0x0000_0080_0000_0000` (PML4[1] — fully unmapped, creates PDPT+PD+PT from scratch), translate confirms correct PA, unmap clears it, translate confirms `None`
- **Test C** — split the 2 MiB huge PD entry covering `KERNEL_STACK` bottom; mark the guard 4 KiB non-present; translate → `None` for guard VA, `Some(_)` for the page above it

## QEMU serial output (Step 8)

```
[...] Page table management smoke test
[OK] A) translate: 0xde1d000 -> 0xde1d000 (identity confirmed)
[OK] B) map_4k at 0x8000000000 -> phys 0x0
[OK] B) translate after map: 0x8000000000 -> 0x0
[OK] B) unmap_4k succeeded
[OK] B) translate after unmap: None
[OK] C) 2 MiB page split, guard marked non-present
[OK] C) guard page translate -> None
[OK] C) page above guard is still present
[OK] Page table management smoke test complete
```

## Test plan

- [x] `cargo build -p ferrous-kernel --target x86_64-unknown-none` — clean (warnings only)
- [x] `cargo build -p ferrous-boot --target x86_64-unknown-uefi` — clean (warnings only)
- [x] `scripts/verify-boot.sh` — PASS; all 4 base checks pass + all 9 Step 8 checks pass
- [x] Pre-commit hook (`cargo fmt`) — passes on both crates

Closes #19