### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bootloader.yml
+++ b/.github/workflows/bootloader.yml
@@ -12,6 +12,9 @@ on:
       - 'boot/**'
       - '.github/workflows/bootloader.yml'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/iamvirul/ferrous-kernel/security/code-scanning/10](https://github.com/iamvirul/ferrous-kernel/security/code-scanning/10)

Add an explicit top-level `permissions` block in `.github/workflows/bootloader.yml` so all jobs inherit least-privilege token access by default.

Best fix here (without changing functionality): insert at workflow root (after `on:` block, before `env:`) the following:

- `permissions:`
  - `contents: read`

This satisfies CodeQL, documents intended access, and is sufficient for checkout and artifact upload usage shown. No imports/methods/dependencies are needed for YAML workflow changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
