### PR TITLE
ci: add dependabot.yml for Actions and Cargo version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+updates:
+
+  # ── GitHub Actions ──────────────────────────────────────────────────────
+  # Covers all .github/workflows/*.yml files.
+  #
+  # Current third-party actions in use:
+  #   dtolnay/rust-toolchain  (pinned to SHA — nightly)
+  #   actions/checkout
+  #   actions/cache
+  #   actions/upload-artifact
+  #   actions/download-artifact
+  #   github/codeql-action/init
+  #   github/codeql-action/analyze
+  #
+  # Dependabot understands SHA-pinned actions: when a new release tag is
+  # published upstream, it will open a PR proposing the updated SHA while
+  # keeping the '# <tag>' comment accurate.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    target-branch: "main"
+    labels:
+      - "type-infrastructure"
+    commit-message:
+      prefix: "ci(deps)"
+
+  # ── Cargo (Rust workspace) ───────────────────────────────────────────────
+  # A single root entry covers the entire workspace (root Cargo.toml lists
+  # all members):
+  #
+  #   boot/          ferrous-boot      — uefi = "0.33", log = "0.4"
+  #   kernel/        ferrous-kernel    — no external crates yet
+  #   lib/boot-info/ ferrous-boot-info — no external crates yet
+  #   lib/core/      ferrous-core      — no external crates yet
+  #   lib/alloc/     ferrous-alloc     — no external crates yet
+  #
+  # Dependency bumps for a bare-metal kernel need manual review and a QEMU
+  # smoke-test run before merging; limit open PRs to keep the queue
+  # manageable.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    target-branch: "main"
+    labels:
+      - "type-infrastructure"
+    commit-message:
+      prefix: "deps(cargo)"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- **`github-actions`** — monitors all `.github/workflows/*.yml` files weekly. Understands SHA-pinned actions (`dtolnay/rust-toolchain` is already pinned); when a new release is published upstream Dependabot will open a PR with the updated SHA and corrected tag comment.
- **`cargo`** — monitors the full workspace from the root `Cargo.toml`, covering all five members: `boot`, `kernel`, `lib/boot-info`, `lib/core`, `lib/alloc`. `open-pull-requests-limit: 5` because kernel dependency bumps require manual review and a QEMU smoke-test before merging.

Both entries run weekly on Mondays at 09:00 UTC, target `main`, and use the existing `type-infrastructure` label.

## Test plan

- [x] Confirm Dependabot is enabled in repo Settings → Code security → Dependabot version updates
- [x] Verify first automated PRs appear on the next Monday schedule