### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/iamvirul/ferrous-kernel/security/code-scanning/17](https://github.com/iamvirul/ferrous-kernel/security/code-scanning/17)

Add an explicit top-level `permissions` block to `.github/workflows/ci.yml` so all jobs inherit minimal token scope.  
Best fix here (without changing workflow behavior) is:

- Add at workflow root (after `on:` block, before `env:`):
  - `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and typical read-only CI tasks. No job-specific overrides are needed based on shown steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
