### PR TITLE
feat(macros): kernel assertion and debug macros in ferrous-core — Phase 1.4.3

### DIFF
--- a/.github/workflows/bootloader.yml
+++ b/.github/workflows/bootloader.yml
@@ -190,6 +190,17 @@ jobs:
             "[WARN ] ferrous_boot: smoke: warn level"
             "[INFO ] ferrous_boot: smoke: info level"
             "[DEBUG] ferrous_boot: smoke: debug level"
+
+            # Phase 1.4.3 — assertion and debug macros
+            "Assertion macro smoke test"
+            "[OK] 11.1) kassert!(true) — no panic"
+            "[OK] 11.3) kassert_eq!(equal) — no panic"
+            "[OK] 11.5) kassert_ne!(unequal) — no panic"
+            "[OK] 11.7) kdebug_assert! — no panic"
+            "[OK] 11.8) kdebug_assert_eq! — no panic"
+            "[OK] 11.9) kdebug_assert_ne! — no panic"
+            "assertions: all macro smoke tests passed"
+            "Assertion macro smoke test complete"
           )
 
           FAILED=0

--- a/boot/Cargo.toml
+++ b/boot/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 uefi = { version = "0.33", features = ["alloc"] }
 log = { version = "0.4", default-features = false }
 ferrous-boot-info = { path = "../lib/boot-info" }
+ferrous-core = { path = "../lib/core" }
 linked_list_allocator = "0.10"
 
 # Boot code requires unsafe for UEFI interface, so we don't inherit workspace lints

--- a/boot/src/main.rs
+++ b/boot/src/main.rs
@@ -22,6 +22,11 @@ mod console;
 mod logger;
 mod memory;
 
+// Kernel assertion macros from ferrous-core (Phase 1.4.3).
+use ferrous_core::{
+    kassert, kassert_eq, kassert_ne, kdebug_assert, kdebug_assert_eq, kdebug_assert_ne,
+};
+
 use core::fmt::Write;
 use linked_list_allocator::LockedHeap;
 use uefi::boot::MemoryType;
@@ -1453,6 +1458,82 @@ fn kernel_main(boot_info: &KernelBootInfo) -> ! {
     log::info!("heap: {} KiB BSS-backed, allocator live", heap_size_kb);
 
     serial_write_str("[OK] Kernel logger smoke test complete\r\n");
+
+    // -----------------------------------------------------------------------
+    // Step 11: Assertion and debug macro smoke test (Phase 1.4.3).
+    //
+    // Exercises every macro exported by `ferrous-core::macros`:
+    //
+    //   kassert!           — basic condition check
+    //   kassert_eq!        — equality with message
+    //   kassert_ne!        — inequality
+    //   kdebug_assert!     — debug-only condition check
+    //   kdebug_assert_eq!  — debug-only equality
+    //   kdebug_assert_ne!  — debug-only inequality
+    //
+    // Each call uses a condition that is *always true*, so no panic is
+    // triggered.  The boot sequence continues normally and prints a
+    // confirmation line that the CI boot verification checks for.
+    //
+    // `kunreachable!`, `kunimplemented!`, and `ktodo!` are NOT called here
+    // because they always panic — they will be exercised by future subsystem
+    // tests that use fault-injection (Phase 3+).
+    //
+    // Expected serial output:
+    //   [OK] 11.1) kassert!(true) — no panic
+    //   [OK] 11.2) kassert_eq!(equal) — no panic
+    //   [OK] 11.3) kassert_ne!(unequal) — no panic
+    //   [OK] 11.4) kdebug_assert! — debug-only, no panic
+    //   [OK] 11.5) kdebug_assert_eq! — debug-only, no panic
+    //   [OK] 11.6) kdebug_assert_ne! — debug-only, no panic
+    //   [INFO ] ferrous_boot: assertions: all macro smoke tests passed
+    serial_write_str("\r\n[...] Assertion macro smoke test\r\n");
+
+    // --- 11.1: kassert! with bare condition ---
+    kassert!(core::mem::size_of::<u64>() == 8);
+    serial_write_str("[OK] 11.1) kassert!(true) — no panic\r\n");
+
+    // --- 11.2: kassert! with format message ---
+    kassert!(HEAP_SIZE > 0, "heap must be non-zero, got {}", HEAP_SIZE);
+    serial_write_str("[OK] 11.2) kassert!(true, msg) — no panic\r\n");
+
+    // --- 11.3: kassert_eq! bare ---
+    kassert_eq!(1u64 + 1, 2u64);
+    serial_write_str("[OK] 11.3) kassert_eq!(equal) — no panic\r\n");
+
+    // --- 11.4: kassert_eq! with message ---
+    kassert_eq!(
+        core::mem::align_of::<u64>(),
+        8usize,
+        "u64 alignment must be 8"
+    );
+    serial_write_str("[OK] 11.4) kassert_eq!(equal, msg) — no panic\r\n");
+
+    // --- 11.5: kassert_ne! bare ---
+    kassert_ne!(0u64, 1u64);
+    serial_write_str("[OK] 11.5) kassert_ne!(unequal) — no panic\r\n");
+
+    // --- 11.6: kassert_ne! with message ---
+    kassert_ne!(HEAP_SIZE, 0usize, "heap size must not be zero");
+    serial_write_str("[OK] 11.6) kassert_ne!(unequal, msg) — no panic\r\n");
+
+    // --- 11.7: kdebug_assert! — active in debug, no-op in release ---
+    //
+    // In debug builds (opt-level=0, debug_assertions=true) this expands to
+    // a kassert! call. In release builds the entire expression is elided.
+    kdebug_assert!(cfg!(debug_assertions));
+    serial_write_str("[OK] 11.7) kdebug_assert! — no panic\r\n");
+
+    // --- 11.8: kdebug_assert_eq! ---
+    kdebug_assert_eq!(2u64 * 2, 4u64);
+    serial_write_str("[OK] 11.8) kdebug_assert_eq! — no panic\r\n");
+
+    // --- 11.9: kdebug_assert_ne! ---
+    kdebug_assert_ne!(0u64, u64::MAX);
+    serial_write_str("[OK] 11.9) kdebug_assert_ne! — no panic\r\n");
+
+    log::info!("assertions: all macro smoke tests passed");
+    serial_write_str("[OK] Assertion macro smoke test complete\r\n");
 
     serial_write_str(
         "\r\nKernel halting. Exception handlers active — any CPU exception will be caught.\r\n",

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -1,12 +1,23 @@
-//! Ferrous Core Library
+//! `ferrous-core` — shared kernel utilities for Ferrous (Phase 1.4.3+).
 //!
-//! Core utilities for Ferrous Kernel that work in `no_std` environments.
+//! A `no_std` library consumed by both the UEFI bootloader (`ferrous-boot`)
+//! and the bare-metal kernel binary (`ferrous-kernel`).  It provides
+//! primitives that would otherwise need to be duplicated across crates.
 //!
-//! This library provides essential utilities without dependencies on the standard library.
+//! # Modules
+//!
+//! | Module | Contents |
+//! |--------|----------|
+//! | [`macros`] | Kernel assertion and debug macros (`kassert!`, `kassert_eq!`, `kdebug_assert!`, `kunreachable!`, …) |
+//!
+//! # `no_std` guarantee
+//!
+//! This crate never depends on `std`, `libc`, or any OS-specific API.  All
+//! items are safe to use in interrupt handlers, early boot code, and any
+//! context where the heap may not be available.
 
 #![no_std]
-#![no_main]
 #![deny(unsafe_code)]
 #![warn(missing_docs)]
 
-// Core library implementation will be added in Phase 1
+pub mod macros;

--- a/lib/core/src/macros.rs
+++ b/lib/core/src/macros.rs
@@ -1,0 +1,328 @@
+//! Kernel assertion and debug macros (Phase 1.4.3).
+//!
+//! Provides two complementary layers:
+//!
+//! ## Always-active assertion macros
+//!
+//! | Macro | Equivalent to | Extra value |
+//! |-------|--------------|-------------|
+//! | [`kassert!`]    | `assert!`    | `[kassert]` prefix in panic message |
+//! | [`kassert_eq!`] | `assert_eq!` | Shows both operand values and source expr |
+//! | [`kassert_ne!`] | `assert_ne!` | Shows both operand values and source expr |
+//!
+//! ## Debug-only macros (`debug_assertions` off in release)
+//!
+//! | Macro | Equivalent to |
+//! |-------|--------------|
+//! | [`kdebug_assert!`]    | `debug_assert!`    |
+//! | [`kdebug_assert_eq!`] | `debug_assert_eq!` |
+//! | [`kdebug_assert_ne!`] | `debug_assert_ne!` |
+//!
+//! ## Reachability markers
+//!
+//! | Macro | Purpose |
+//! |-------|---------|
+//! | [`kunreachable!`]   | Mark logically impossible code paths |
+//! | [`kunimplemented!`] | Mark stubs not yet written |
+//! | [`ktodo!`]          | Alias for `kunimplemented!` |
+//!
+//! # Why custom macros?
+//!
+//! Rust's `core` library already provides `assert!`, `debug_assert!`, etc.
+//! They work correctly in `no_std` and call into the crate's `#[panic_handler]`
+//! on failure.  The `k`-prefixed variants add:
+//!
+//! - A `[kassert]` / `[kassert_eq]` / `[kunreachable]` prefix in the panic
+//!   message so assertion failures are instantly identifiable in serial output,
+//!   even among other log lines.
+//! - Operand source expressions in `kassert_eq!` / `kassert_ne!` — the message
+//!   says *which* variables were compared, not just their values.
+//! - Uniform naming under `ferrous_core::` so kernel subsystems have a single
+//!   import path regardless of which binary (`boot`, `kernel`) they're compiled
+//!   into.
+//!
+//! # Panics and the panic handler
+//!
+//! All macros use [`core::panic!`] on failure.  The caller's `#[panic_handler]`
+//! (enhanced in Phase 1.4.2) takes over from there: it prints a banner, source
+//! location, the formatted message, and a stack trace to COM1.
+//!
+//! # Zero cost in release
+//!
+//! `kdebug_assert!`, `kdebug_assert_eq!`, and `kdebug_assert_ne!` expand to
+//! nothing when `debug_assertions` is not set (the default for `--release`
+//! builds).  All other macros remain active in release so critical invariants
+//! are always checked.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use ferrous_core::{kassert, kassert_eq, kassert_ne};
+//! use ferrous_core::{kdebug_assert, kunreachable};
+//!
+//! // Basic assertion
+//! kassert!(ptr as usize % 4096 == 0, "frame must be page-aligned");
+//!
+//! // Equality check with automatic value display on failure
+//! kassert_eq!(entry & 1, 1u64, "PTE present bit must be set");
+//!
+//! // Debug-only — zero cost in release
+//! kdebug_assert!(free_frames > 0);
+//!
+//! // Unreachable branch
+//! match signal {
+//!     0 => handle_zero(),
+//!     1 => handle_one(),
+//!     _ => kunreachable!("unexpected signal: {}", signal),
+//! }
+//! ```
+
+// ---------------------------------------------------------------------------
+// Always-active assertions
+// ---------------------------------------------------------------------------
+
+/// Kernel assertion macro.
+///
+/// Panics if `$cond` evaluates to `false`. The panic message is prefixed with
+/// `[kassert FAILED]` so it stands out clearly in serial output.
+///
+/// # Usage
+///
+/// ```no_run
+/// # use ferrous_core::kassert;
+/// kassert!(ptr != core::ptr::null_mut());
+/// kassert!(size % 4096 == 0, "size must be page-aligned, got {}", size);
+/// ```
+#[macro_export]
+macro_rules! kassert {
+    ($cond:expr) => {{
+        if !$cond {
+            ::core::panic!("[kassert FAILED] {}", ::core::stringify!($cond));
+        }
+    }};
+    ($cond:expr, $($arg:tt)+) => {{
+        if !$cond {
+            ::core::panic!("[kassert FAILED] {}", ::core::format_args!($($arg)+));
+        }
+    }};
+}
+
+/// Kernel equality assertion.
+///
+/// Panics if `$left != $right`, printing both the source expressions and their
+/// evaluated values. Requires both sides to implement [`core::fmt::Debug`].
+///
+/// # Usage
+///
+/// ```no_run
+/// # use ferrous_core::kassert_eq;
+/// kassert_eq!(cr3_readback, pml4_phys);
+/// kassert_eq!(frame.start_address() % 4096, 0u64, "frame not page-aligned");
+/// ```
+#[macro_export]
+macro_rules! kassert_eq {
+    ($left:expr, $right:expr) => {{
+        match (&$left, &$right) {
+            (l, r) => {
+                if l != r {
+                    ::core::panic!(
+                        "[kassert_eq FAILED] `{} == {}`\n  left:  {:?}\n  right: {:?}",
+                        ::core::stringify!($left),
+                        ::core::stringify!($right),
+                        l,
+                        r,
+                    );
+                }
+            }
+        }
+    }};
+    ($left:expr, $right:expr, $($arg:tt)+) => {{
+        match (&$left, &$right) {
+            (l, r) => {
+                if l != r {
+                    ::core::panic!(
+                        "[kassert_eq FAILED] {} — `{} == {}`\n  left:  {:?}\n  right: {:?}",
+                        ::core::format_args!($($arg)+),
+                        ::core::stringify!($left),
+                        ::core::stringify!($right),
+                        l,
+                        r,
+                    );
+                }
+            }
+        }
+    }};
+}
+
+/// Kernel inequality assertion.
+///
+/// Panics if `$left == $right`, printing both the source expressions and their
+/// evaluated values. Requires both sides to implement [`core::fmt::Debug`].
+///
+/// # Usage
+///
+/// ```no_run
+/// # use ferrous_core::kassert_ne;
+/// kassert_ne!(frame_a, frame_b, "allocator returned duplicate frames");
+/// ```
+#[macro_export]
+macro_rules! kassert_ne {
+    ($left:expr, $right:expr) => {{
+        match (&$left, &$right) {
+            (l, r) => {
+                if l == r {
+                    ::core::panic!(
+                        "[kassert_ne FAILED] `{} != {}`\n  both: {:?}",
+                        ::core::stringify!($left),
+                        ::core::stringify!($right),
+                        l,
+                    );
+                }
+            }
+        }
+    }};
+    ($left:expr, $right:expr, $($arg:tt)+) => {{
+        match (&$left, &$right) {
+            (l, r) => {
+                if l == r {
+                    ::core::panic!(
+                        "[kassert_ne FAILED] {} — `{} != {}`\n  both: {:?}",
+                        ::core::format_args!($($arg)+),
+                        ::core::stringify!($left),
+                        ::core::stringify!($right),
+                        l,
+                    );
+                }
+            }
+        }
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// Debug-only assertions
+// ---------------------------------------------------------------------------
+
+/// Debug-only kernel assertion.
+///
+/// Expands to [`kassert!`] when `debug_assertions` is set (the default for
+/// `cargo build` without `--release`). **Compiles to nothing** in release
+/// builds — no code is generated, the condition is never evaluated.
+///
+/// Use for invariant checks that are expensive or would fire on edge cases in
+/// production. Prefer [`kassert!`] for critical invariants that must hold
+/// in all builds.
+///
+/// # Usage
+///
+/// ```no_run
+/// # use ferrous_core::kdebug_assert;
+/// kdebug_assert!(free_frames > 0, "allocator must have free frames");
+/// ```
+#[macro_export]
+macro_rules! kdebug_assert {
+    ($($arg:tt)+) => {{
+        #[cfg(debug_assertions)]
+        $crate::kassert!($($arg)+);
+    }};
+}
+
+/// Debug-only kernel equality assertion.
+///
+/// Expands to [`kassert_eq!`] in debug builds, **compiles to nothing** in
+/// release. See [`kdebug_assert!`] for rationale.
+#[macro_export]
+macro_rules! kdebug_assert_eq {
+    ($($arg:tt)+) => {{
+        #[cfg(debug_assertions)]
+        $crate::kassert_eq!($($arg)+);
+    }};
+}
+
+/// Debug-only kernel inequality assertion.
+///
+/// Expands to [`kassert_ne!`] in debug builds, **compiles to nothing** in
+/// release. See [`kdebug_assert!`] for rationale.
+#[macro_export]
+macro_rules! kdebug_assert_ne {
+    ($($arg:tt)+) => {{
+        #[cfg(debug_assertions)]
+        $crate::kassert_ne!($($arg)+);
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// Reachability markers
+// ---------------------------------------------------------------------------
+
+/// Mark a code path as logically unreachable.
+///
+/// Triggers a kernel panic (not undefined behaviour) with a clear message
+/// identifying the call site. Unlike `core::unreachable!`, this macro never
+/// calls `core::hint::unreachable_unchecked()` — even in release builds it
+/// panics, because silent undefined behaviour in kernel code is unacceptable.
+///
+/// # Usage
+///
+/// ```no_run
+/// # use ferrous_core::kunreachable;
+/// match irq_vector {
+///     32..=47 => handle_irq(irq_vector),
+///     _ => kunreachable!("unexpected interrupt vector: {:#x}", irq_vector),
+/// }
+/// ```
+#[macro_export]
+macro_rules! kunreachable {
+    () => {{
+        ::core::panic!(
+            "[kunreachable] entered unreachable code at {}:{}:{}",
+            ::core::file!(),
+            ::core::line!(),
+            ::core::column!(),
+        );
+    }};
+    ($($arg:tt)+) => {{
+        ::core::panic!("[kunreachable] {}", ::core::format_args!($($arg)+));
+    }};
+}
+
+/// Mark a function or branch as not yet implemented.
+///
+/// Always panics with a `[kunimplemented]` prefix. Use during development to
+/// mark stubs; replace with real implementations before shipping.
+///
+/// # Usage
+///
+/// ```no_run
+/// # use ferrous_core::kunimplemented;
+/// fn schedule_next_thread() -> ! {
+///     kunimplemented!("scheduler not yet implemented");
+/// }
+/// ```
+#[macro_export]
+macro_rules! kunimplemented {
+    () => {{
+        ::core::panic!(
+            "[kunimplemented] not yet implemented at {}:{}:{}",
+            ::core::file!(),
+            ::core::line!(),
+            ::core::column!(),
+        );
+    }};
+    ($($arg:tt)+) => {{
+        ::core::panic!("[kunimplemented] {}", ::core::format_args!($($arg)+));
+    }};
+}
+
+/// Alias for [`kunimplemented!`].
+///
+/// Marks work-in-progress code that must be completed before the feature is
+/// usable. Behaves identically to [`kunimplemented!`] — always panics.
+#[macro_export]
+macro_rules! ktodo {
+    () => {
+        $crate::kunimplemented!()
+    };
+    ($($arg:tt)+) => {
+        $crate::kunimplemented!($($arg)+)
+    };
+}

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -177,6 +177,17 @@ EXPECTED_STRINGS=(
     "[INFO ] ferrous_boot: smoke: info level"
     "[DEBUG] ferrous_boot: smoke: debug level"
     "[INFO ] ferrous_boot: heap:"
+
+    # Phase 1.4.3 — assertion and debug macros
+    "Assertion macro smoke test"
+    "[OK] 11.1) kassert!(true) — no panic"
+    "[OK] 11.3) kassert_eq!(equal) — no panic"
+    "[OK] 11.5) kassert_ne!(unequal) — no panic"
+    "[OK] 11.7) kdebug_assert! — no panic"
+    "[OK] 11.8) kdebug_assert_eq! — no panic"
+    "[OK] 11.9) kdebug_assert_ne! — no panic"
+    "assertions: all macro smoke tests passed"
+    "Assertion macro smoke test complete"
 )
 
 run_and_verify() {


### PR DESCRIPTION
## Summary

Implements Phase 1.4.3: Basic Assertions and Debug Macros, resolves #23.

- **New `lib/core/src/macros.rs`** — 10 macros covering the full assertion surface, usable from any `no_std` kernel crate
- **`boot/src/main.rs` Step 11** — nine sub-tests, all passing in QEMU; 33/33 boot verification strings PASS
- **CI updated** with 8 new Phase 1.4.3 expected strings

## Macro inventory

| Macro | Always active | Zero-cost in release |
|---|---|---|
| `kassert!(cond)` / `kassert!(cond, fmt…)` | ✅ | — |
| `kassert_eq!(l, r)` / with message | ✅ | — |
| `kassert_ne!(l, r)` / with message | ✅ | — |
| `kdebug_assert!` | debug only | ✅ |
| `kdebug_assert_eq!` | debug only | ✅ |
| `kdebug_assert_ne!` | debug only | ✅ |
| `kunreachable!()` / with message | ✅ | — |
| `kunimplemented!()` / with message | ✅ | — |
| `ktodo!()` | ✅ | — |

## Design decisions

**`kunreachable!` always panics, never calls `unreachable_unchecked()`.**  
Silent undefined behaviour in kernel code is unacceptable. The macro pays the cost of a panic call in release but guarantees safety — no UB even if a "logically impossible" branch is reached due to hardware bugs or memory corruption.

**`kdebug_*` use `#[cfg(debug_assertions)]`, not `if cfg!(…)`.** The `cfg` attribute eliminates the call entirely; `if cfg!` produces dead code that the optimizer must remove (unreliable at `opt-level=0`).

**All panics go through the Phase 1.4.2 enhanced handler.**  
`kassert!` expands to `core::panic!` → `#[panic_handler]` → structured banner + source location + stack trace on COM1.

**`ferrous-core` has no dependencies** — it's a pure `no_std` macro crate, safe for interrupt handlers and early boot contexts.

## Test plan

- [x] `./scripts/verify-boot.sh` — 33/33 strings PASS (phases 1.1 through 1.4.3)
- [x] 9 assertion sub-tests in Step 11 of `kernel_main` — none triggered a panic
- [x] `cargo fmt` pre-commit hook passes for both `boot` and `lib/core`
- [ ] CI green on push